### PR TITLE
fix(home): count active projects only + live-refresh on projects/USER.md changes

### DIFF
--- a/src/home/homePanel.ts
+++ b/src/home/homePanel.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { getMonthData, openDailyNote } from './calendar';
 import * as path from 'path';
-import { operatorName, primaryName, countNotes, vaultRoot } from './vault';
+import { operatorName, primaryName, countNotes, vaultRoot, frameworkRoot } from './vault';
 import { launchAios, runInPrimarySession, runInActiveClaude } from '../rituals/runner';
 import { discoverAgents } from '../agents/agents';
 import { listRunningAgents } from '../agents/running';
@@ -82,6 +82,35 @@ export class HomeViewProvider implements vscode.WebviewViewProvider {
       ew.onDidCreate(onExp);
       ew.onDidDelete(onExp);
       webviewView.onDidDispose(() => ew.dispose());
+    }
+    // Refresh the Projects count when project notes change — added/removed, or
+    // re-categorized via frontmatter `status` (archiving/pausing a project), or
+    // moved into a subfolder. Watch is recursive (`**/*.md`) so a move into
+    // projects/archived/ etc. fires too; countNotes() itself stays non-recursive,
+    // so the moved note drops out of the (active, top-level) count either way.
+    if (v) {
+      const pw = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(vscode.Uri.file(path.join(v, '00 - notes', 'projects')), '**/*.md')
+      );
+      const onProj = () => this.postState();
+      pw.onDidChange(onProj);
+      pw.onDidCreate(onProj);
+      pw.onDidDelete(onProj);
+      webviewView.onDidDispose(() => pw.dispose());
+    }
+    // Refresh Companies/Collaboration when USER.md changes (the Companies table
+    // is parsed from USER.md → `## Companies (mounted)`), so mounting/unmounting
+    // a company shows up live without a reload.
+    const root = frameworkRoot();
+    if (root) {
+      const uw = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(vscode.Uri.file(root), 'USER.md')
+      );
+      const onUser = () => this.postState();
+      uw.onDidChange(onUser);
+      uw.onDidCreate(onUser);
+      uw.onDidDelete(onUser);
+      webviewView.onDidDispose(() => uw.dispose());
     }
   }
 

--- a/src/home/vault.ts
+++ b/src/home/vault.ts
@@ -85,12 +85,45 @@ export function contextDir(kind: ContextKind): string | undefined {
   return path.join(v, sub);
 }
 
-/** Count top-level .md notes in a context/projects folder (excludes _index.md). */
+/**
+ * Note statuses that are NOT "live" work and should be excluded from counts.
+ * Mirrors the AIOS project taxonomy: `active` (counted) vs
+ * `paused` / `engagement` / `archived` / `idea` (not counted). Context notes
+ * (declared/observed) carry no `status`, so they're always counted.
+ */
+const NON_ACTIVE_STATUS = new Set(['archived', 'paused', 'engagement', 'idea']);
+
+/** Read the `status:` frontmatter value of a note (lowercased), if present. */
+function noteStatus(file: string): string | undefined {
+  try {
+    const txt = fs.readFileSync(file, 'utf8').replace(/^\uFEFF/, ''); // strip BOM
+    const fm = txt.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!fm) return undefined;
+    // No end anchor: tolerate trailing whitespace or a YAML inline comment
+    // (`status: archived  # migrated`). The value is bounded by the frontmatter block.
+    const m = fm[1].match(/^status:\s*["']?([A-Za-z-]+)/m);
+    return m ? m[1].toLowerCase() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Count top-level .md notes in a context/projects folder (excludes `_index.md`).
+ * For `projects`, notes whose frontmatter `status` is non-active
+ * (archived/paused/engagement/idea) are excluded, so the count reflects the
+ * *active* taxonomy rather than a raw file tally. `declared`/`observed` notes
+ * carry no `status`, so their read is skipped entirely (just a file tally).
+ * Non-recursive by design — non-active notes filed into subfolders
+ * (e.g. `projects/archived/`) are absent from `readdirSync` and so also excluded.
+ */
 export function countNotes(kind: ContextKind): number {
   const dir = contextDir(kind);
   if (!dir) return 0;
   try {
-    return fs.readdirSync(dir).filter((f) => f.endsWith('.md') && f !== '_index.md').length;
+    const candidates = fs.readdirSync(dir).filter((f) => f.endsWith('.md') && f !== '_index.md');
+    if (kind !== 'projects') return candidates.length;
+    return candidates.filter((f) => !NON_ACTIVE_STATUS.has(noteStatus(path.join(dir, f)) ?? '')).length;
   } catch {
     return 0;
   }


### PR DESCRIPTION
## Problem

`countNotes('projects')` tallies *every* `.md` in `00 - notes/projects/` (minus `_index.md`), ignoring `status`. The Home **Projects** count therefore doesn't reflect the AIOS taxonomy: after a poda/restructure that re-categorizes notes via frontmatter (`active`/`paused`/`engagement`/`archived`/`idea`), the number doesn't move — archiving/pausing a project leaves it unchanged, and adding a note *raises* it even if it's not active work. Real case: an operator pruned 17 notes to 12 active and Glass kept showing 17.

There's also no `FileSystemWatcher` on `projects/` or `USER.md`, so the **Projects** count and the **Companies** table go stale until the panel is hidden→shown or the window reloads (today's watchers cover only `01 - calendar`, observed, `03 - export`).

## Fix

**1. Status-aware count** (`src/home/vault.ts`)
- Exclude notes whose frontmatter `status` is `archived`/`paused`/`engagement`/`idea`.
- `declared`/`observed` carry no `status` → unaffected (read skipped; plain tally).
- Non-recursive, so non-active notes filed into subfolders (`projects/archived/`, …) are also excluded — works for flat or subfoldered vaults.

**2. Live refresh** (`src/home/homePanel.ts`)
- `FileSystemWatcher`s on `00 - notes/projects/` (recursive) and `USER.md`, mirroring the existing watcher pattern → `postState()` on change, disposed on `onDidDispose`.

## Notes
- `frameworkRoot` already exported from `vault.ts`; now imported in `homePanel.ts` for the USER.md watcher.
- **Typechecks clean** (`tsc --noEmit`). Passed an independent code review (handles YAML inline comments, BOM, skips wasted I/O on declared/observed). Not yet smoke-tested in a running IDE host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)