### PR TITLE
feat(home): add weekly-plan nudge to the contextual ritual banner

### DIFF
--- a/src/home/homePanel.ts
+++ b/src/home/homePanel.ts
@@ -210,6 +210,7 @@ export class HomeViewProvider implements vscode.WebviewViewProvider {
   }
 
   private postState(): void {
+    const now = new Date();
     this.post({
       type: 'state',
       operator: operatorName(),
@@ -228,7 +229,7 @@ export class HomeViewProvider implements vscode.WebviewViewProvider {
       projects: countNotes('projects'),
       goAgents: countAgentSuggestions(),
       learnings: recentLearnings(4).map((l) => ({ title: l.title, date: l.date, source: l.source, file: l.file, line: l.line })),
-      nudge: showNudges() ? nudgeState(new Date().getHours(), this.lastRunningCount) : null,
+      nudge: showNudges() ? nudgeState(now.getHours(), now.getDay(), this.lastRunningCount) : null,
       outputs: recentOutputs(6).map((o) => ({ name: o.name, group: o.group, path: o.path })),
       reports: recentReports(5).map((r) => ({ name: r.name, path: r.path }))
     });

--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -105,7 +105,31 @@ function latestDailyNote(): string | undefined {
  * Close-of-Day section yet — the moment a non-dev silently breaks the
  * compounding (run /today, work, never close → nothing gets captured).
  */
-export interface Nudge { kind: 'plan' | 'sessions' | 'close'; icon: string; label: string; command?: string; }
+export interface Nudge { kind: 'plan' | 'sessions' | 'close' | 'week'; icon: string; label: string; command?: string; }
+
+/** ISO-8601 week (Mon-based) for a date — matches the AIOS `{YYYY}-W{WW}` weekly-note convention. */
+function isoWeek(d: Date): { year: number; week: number } {
+  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  date.setUTCDate(date.getUTCDate() + 3 - ((date.getUTCDay() + 6) % 7)); // shift to this week's Thursday
+  const week1 = new Date(Date.UTC(date.getUTCFullYear(), 0, 4));
+  const week = 1 + Math.round(((date.getTime() - week1.getTime()) / 86400000 - 3 + ((week1.getUTCDay() + 6) % 7)) / 7);
+  return { year: date.getUTCFullYear(), week };
+}
+
+/** True if THIS week's weekly-plan note (`{YYYY}-W{WW}-plan.md`) already exists under 01 - calendar/. */
+function weeklyPlanExists(): boolean {
+  const v = vaultRoot();
+  if (!v) return false;
+  const { year, week } = isoWeek(new Date());
+  const name = `${year}-W${String(week).padStart(2, '0')}-plan.md`;
+  const cal = path.join(v, '01 - calendar');
+  try {
+    for (const mo of fs.readdirSync(cal).filter((d) => /^\d{4}-\d{2}$/.test(d))) {
+      if (fs.existsSync(path.join(cal, mo, name))) return true;
+    }
+  } catch { /* ignore */ }
+  return false;
+}
 
 /**
  * The first actionable 💡 ritual the daily note suggests — a backticked
@@ -128,14 +152,16 @@ function suggestedRitual(md: string): { command: string; short: string } | null 
 }
 
 /**
- * Contextual ritual nudge for the Home banner, by time of day + state:
- *   no today-note     → plan the day (/today)
- *   evening (≥17h)    → close the day
- *   morning (<12h)    → the note's 💡 suggested ritual (planning-type only)
- *   daytime + live sessions → wrap open sessions before close-day
- * Pure given the inputs — caller passes the local hour + live-session count.
+ * Contextual ritual nudge for the Home banner, by time of day + day of week + state:
+ *   no today-note            → plan the day (/today)
+ *   evening (≥17h) + unclosed → close the day
+ *   Mon/Tue + no weekly plan  → plan the week (/7plan)
+ *   morning (<12h)           → the note's 💡 suggested ritual (planning-type only)
+ *   daytime + live sessions  → wrap open sessions before close-day
+ * Caller passes the local hour + weekday (0=Sun…6=Sat) + live-session count;
+ * filesystem state (today's note, close-of-day, weekly plan) is read here.
  */
-export function nudgeState(hour: number, runningCount: number): Nudge | null {
+export function nudgeState(hour: number, weekday: number, runningCount: number): Nudge | null {
   const note = latestDailyNote();
   const isToday = !!note && path.basename(note, '.md') === todayLocalIso();
   if (!isToday) return { kind: 'plan', icon: '☀️', label: 'Plan your day', command: '/aios:today' };
@@ -144,6 +170,13 @@ export function nudgeState(hour: number, runningCount: number): Nudge | null {
   const isClosed = /close[\s-]?of[\s-]?day|^#{1,4}.*\bclose\b.*\bday\b/im.test(md);
   if (hour >= 17 && !isClosed) {
     return { kind: 'close', icon: '🌙', label: "Close the day — capture what compounded before it's lost", command: '/aios:close-day' };
+  }
+  // Early-week: on Mon/Tue, during the day (6–17h), nudge the weekly plan if it isn't done yet.
+  // Day-gated so it never fires late at night or after the day is closed (the evening-close guard
+  // above owns ≥17h). Intentionally ranks above the morning 💡 / wrap-sessions nudges — the week
+  // kickoff is the Mon/Tue priority; wrap-sessions only matters near close time anyway.
+  if ((weekday === 1 || weekday === 2) && hour >= 6 && hour < 17 && !weeklyPlanExists()) {
+    return { kind: 'week', icon: '🗓️', label: `Plan your week — it's ${weekday === 1 ? 'Monday' : 'Tuesday'}`, command: '/aios:7plan' };
   }
   if (hour < 12) {
     const r = suggestedRitual(md);


### PR DESCRIPTION
## What

Extends `nudgeState()` (the Home banner's contextual ritual nudge) with an **early-week slot**: on **Monday or Tuesday**, during the day (6–17h), if **this ISO week's weekly-plan note (`{YYYY}-W{WW}-plan.md`) doesn't exist yet**, the banner nudges **`/aios:7plan`** (kind `'week'`, 🗓️ "Plan your week — it's Monday/Tuesday").

## Why

The banner already surfaces plan / close / suggested-ritual / wrap-sessions by time + state, but had no slot for the weekly ritual — so the week-kickoff (`/7plan`) was the one ritual Glass never reminded you about. This closes that gap, keeping the "one banner = the right next ritual for this moment" model.

## Design

- **New helpers** (`insights.ts`): `isoWeek(date)` (canonical ISO-8601, Mon-based) + `weeklyPlanExists()` (scans `01 - calendar/{YYYY-MM}/` month folders for the week's plan file — handles a week spanning two month folders).
- **Priority**: the week slot sits **below** the evening-close guard (an unclosed evening still wins) and is **day-gated (6–17h)** so it never fires post-close or late at night. It ranks **above** the morning 💡 / wrap-sessions nudges — the week kickoff is the Mon/Tue priority (wrap-sessions only matters near close time).
- **Decoupled / no taxonomy assumptions**: pure time + day + file-existence; nothing operator-specific hardcoded.
- Caller passes `weekday` from a single `Date()`. The webview renders it through the existing generic nudge path (`kind:'week'` falls through to command-run; per-kind dismiss stays isolated).

## Notes
- **Typechecks clean** (`tsc --noEmit`). Passed an independent code review — `isoWeek` verified against W22/2026 (matches the vault's `2026-W22-plan.md`) + year-boundary cases (2027-01-01 → W53/2026); downstream `kind:'week'` handling + dismiss isolation confirmed. Not yet smoke-tested in a running IDE host.
- Assumes the AIOS `{YYYY}-W{WW}-plan.md` (ISO week) weekly-note convention — flag if `/7plan` numbers weeks differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)