### PR TITLE
fix(nudge): ignore future-dated daily notes in latestDailyNote

### DIFF
--- a/src/insights/insights.ts
+++ b/src/insights/insights.ts
@@ -85,15 +85,25 @@ function todayLocalIso(): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
-/** Latest daily note path under <vault>/01 - calendar/. */
+/**
+ * Latest daily note path under <vault>/01 - calendar/, **ignoring future-dated
+ * notes**. `/7plan` can pre-create skeleton notes for the days ahead; those are
+ * plans, not the most recent *actual* daily note. Counting a future skeleton as
+ * "latest" breaks the nudge engine (its basename ≠ today → "Plan your day" fires
+ * forever) and close-day detection. Cap at today so "latest" = "most recent so far".
+ */
 function latestDailyNote(): string | undefined {
   const v = vaultRoot();
   if (!v) return undefined;
   const cal = path.join(v, '01 - calendar');
+  const today = todayLocalIso();
   try {
     const months = fs.readdirSync(cal).filter((d) => /^\d{4}-\d{2}$/.test(d)).sort();
     for (const mo of months.reverse()) {
-      const files = fs.readdirSync(path.join(cal, mo)).filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f)).sort();
+      const files = fs
+        .readdirSync(path.join(cal, mo))
+        .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f) && f.slice(0, 10) <= today)
+        .sort();
       if (files.length) return path.join(cal, mo, files[files.length - 1]);
     }
   } catch { /* ignore */ }

--- a/src/tasks/goWithAgents.ts
+++ b/src/tasks/goWithAgents.ts
@@ -6,11 +6,17 @@ import { launchSpawn } from '../rituals/runner';
 
 interface Suggestion { task: string; agents: string[]; raw: string; }
 
-/** Newest `YYYY-MM-DD.md` under `<vault>/01 - calendar/YYYY-MM/`. */
+/**
+ * Newest `YYYY-MM-DD.md` under `<vault>/01 - calendar/YYYY-MM/`, **ignoring
+ * future-dated notes** (e.g. `/7plan` skeletons for the days ahead). We want the
+ * most recent *actual* daily note to read agent suggestions from, not a plan.
+ */
 function latestDailyNote(): string | undefined {
   const v = vaultRoot();
   if (!v) return undefined;
   const cal = path.join(v, '01 - calendar');
+  const now = new Date();
+  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
   let months: string[];
   try {
     months = fs.readdirSync(cal).filter((d) => /^\d{4}-\d{2}$/.test(d)).sort();
@@ -20,7 +26,10 @@ function latestDailyNote(): string | undefined {
   for (const m of months.reverse()) {
     let files: string[];
     try {
-      files = fs.readdirSync(path.join(cal, m)).filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f)).sort();
+      files = fs
+        .readdirSync(path.join(cal, m))
+        .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f) && f.slice(0, 10) <= today)
+        .sort();
     } catch {
       continue;
     }


### PR DESCRIPTION
## Problem

The contextual ritual nudge ("Plan your day" / "Plan your week" / "Close the day") and the *go-with-agents* feature both resolve the current daily note via `latestDailyNote()`, which returned the **highest-dated** `YYYY-MM-DD.md` under `01 - calendar/`.

`/aios:7plan` legitimately pre-creates **skeleton notes for the days ahead**. So with skeletons for 6/09–6/12 and today = 6/08, `latestDailyNote()` returned `2026-06-12`. Then:

```ts
const isToday = basename(latest) === todayLocalIso();   // "2026-06-12" === "2026-06-08" → false
if (!isToday) return { kind: 'plan', label: 'Plan your day', ... };
```

→ **"Plan your day" fires forever** even though today's note exists, and a window-reload doesn't help (the skeletons are real on disk). The close-day detection (`hour ≥ 17 && !isClosed`) also read the wrong, future note. Same root cause surfaces in `/aios:today`'s close-day precondition check (`MISSING (2026-06-12)` false positive) — that lives in the aios command, out of scope here.

## Fix

Cap both copies of `latestDailyNote()` (`src/insights/insights.ts` + `src/tasks/goWithAgents.ts`) at today — filter filenames to `f.slice(0, 10) <= today`. "Latest" now means *most recent actual daily note*, not *furthest-dated plan*.

No caller wants a future note: the nudge engine, the agent-badge count, and go-with-agents all act on today's record. Skeletons still populate the week's calendar view (that path is unaffected) — they just no longer masquerade as the latest note.

- `nudgeState` → today's note detected → nudge clears.
- Months loop: a month with only future notes falls through to the previous month; fresh-vault returns `undefined` (unchanged graceful fallback).
- ISO-date string `<=` is lexicographically correct across year boundaries.

`npm run compile` (tsc) clean. Reviewed for caller behavior, month-loop fall-through, shadowing, and date-string edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)