### PR TITLE
v0.2.1 — AIOS themes + theme co-switch · in-place Explorer auto-refresh · add-folder fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-06-18
+
+> Two matching **workbench themes** so the whole IDE speaks Glass's palette, plus a fix for adding Workspace folders to the Explorer.
+
+### Added
+- **AIOS Dark + AIOS Light workbench themes** — pick them from *Preferences: Color Theme* (⌘K ⌘T). Built from the exact Glass tokens (deep-black / paper canvas, coral accent, `ok` green, the same gold/green/red git colours as the Explorer), so the editor, terminal, activity bar, and tabs read as one tool with the Glass panels. Terminal ANSI maps to the Glass family (bright-red = coral); cursor, active-tab underline, and badges carry the accent. Pair with `window.autoDetectColorScheme` to follow the OS the way Glass does.
+- **Explorer auto-updates in place (IDE-style)** — create a file (e.g. save a screenshot into a Workspace folder) and the row appears on its own; delete one and it vanishes. Done via a **targeted re-list**: the root watcher reports *which* folder changed, and only that one folder is re-listed and row-diffed — no full repaint, so zero flicker; one `readdir` per change, so no memory cost; the live git-marker path is untouched. Folders that aren't expanded/visible are no-ops, so the write-heavy vault/framework roots don't thrash. A ⟳ title-bar action does a full preserve-expansion re-read as a manual catch-all.
+- **Theme co-switch (opt-in, never hijacks)** — cog → *Theme (Glass + IDE)* → **AIOS Dark / AIOS Light** moves *both* Glass and the IDE theme together (the "move into AIOS" action). Once the IDE is on an AIOS theme, the header sun/moon toggle — and `window.autoDetectColorScheme` — flip the IDE in lockstep with Glass; picking an AIOS theme from ⌘K⌘T flips Glass too. The co-switch *only* fires when you're already on an AIOS theme, so a personal IDE theme (GitHub Dark, Tokyo Night…) is never touched. *Glass dark/light only* entries reskin the panels alone.
+  - **Smart toggle.** While your IDE is on a non-AIOS theme, the header toggle asks each time — *Glass only* or *Glass + IDE* — so you're never trapped in one mode; the moment you pick *Glass + IDE* you're on an AIOS theme, and from then on the toggle co-switches both silently.
+
+### Fixed
+- **Adding a Workspace folder to the Explorer now refreshes immediately.** A lost directory-listing reply (a modal open-dialog could interrupt the round-trip) had no timeout, so the paint awaiting it hung *before* rendering the WORKSPACE group — the new folder only appeared after a delete-and-re-add. `fsList` now has a 5s safety net + idempotent resolve, so the tree can never be stranded; and adding a folder now expands to + selects it (instant feedback).
+
 ## [0.2.0] — 2026-06-18
 
 > The visibility release. A **light theme** (same coral, paper canvas) you can toggle anywhere, and **AIOS Files** reborn as a real **Explorer** — a collapsible Framework / Vault / Workspace tree with **live git status**, an **IDE-style icon pack**, hidden-file control, and ⌘-click to source. Plus a quieter, glyph-driven header, a per-session memory read, and a focus fix so a follow-up Enter stops spawning duplicate terminals.

--- a/media/files.js
+++ b/media/files.js
@@ -84,7 +84,16 @@
   let reqSeq = 0;
   const pending = new Map();
   function fsList(dir) {
-    return new Promise((resolve) => { const id = ++reqSeq; pending.set(id, resolve); vscode.postMessage({ type: 'list', dir, reqId: id }); });
+    // Resolve idempotently, and ALWAYS resolve — a lost 'listing' reply (e.g. the
+    // round-trip interrupted by a modal open-dialog) must not strand the awaiting
+    // paint forever, or sections built after it (the WORKSPACE group) never render.
+    return new Promise((resolve) => {
+      const id = ++reqSeq;
+      const done = (v) => { if (pending.delete(id)) resolve(v); };
+      pending.set(id, done);
+      vscode.postMessage({ type: 'list', dir, reqId: id });
+      setTimeout(() => done([]), 5000); // safety net: never hang the tree
+    });
   }
 
   // ── live git: reconcile status onto every rendered row (no re-expand) ──
@@ -149,46 +158,84 @@
     });
   }
 
+  // path → its children-container element (a section box or a folder's .xkids), so a
+  // single changed folder can be re-listed in place without touching the rest of the tree.
+  const dirContainers = new Map();
+
+  // Build ONE row (file or folder) with all its wiring, and return it (not appended —
+  // buildTree appends in bulk; relistFolder inserts a single new row in order).
+  function makeRow(e, depth, base) {
+    const row = el('div', 'xrow' + (e.dir ? ' dir' : '') + (e.git ? ' g' + e.git : '') + (e.name.startsWith('.') ? ' hidden' : ''));
+    row.dataset.path = e.path; // lets live git pushes find + recolor this row
+    row.style.paddingLeft = ((base || 14) + depth * 9) + 'px'; // content nests under its section (tight)
+    const ic = el('span', 'xicon'); ic.innerHTML = e.dir ? icon('chevR', 11) : fileIconSvg(e.name);
+    const nm = el('span', 'xname');
+    const pm = e.dir ? e.name.match(/^(\d+ - )(.+)$/) : null; // dim the "00 - " ordering prefix
+    if (pm) { nm.append(el('span', 'xpre', pm[1]), document.createTextNode(pm[2])); }
+    else nm.textContent = e.dir ? e.name : e.name.replace(/\.md$/i, '');
+    row.append(ic, nm);
+    if (e.git) row.append(e.dir ? el('span', 'gdot') : el('span', 'gst', e.git)); // folders → dot, files → letter
+    attachCtx(row, e.path);
+    attachDrag(row, e.path);
+    if (e.dir) {
+      let kids = null;
+      const guideX = ((base || 14) + depth * 9 + 7) + 'px'; // child guide line under this chevron
+      const ensure = async () => { // expand-only (used by click + auto-reveal)
+        if (!kids) { kids = el('div', 'xkids'); kids.style.setProperty('--g', guideX); row.after(kids); ic.innerHTML = icon('chevD', 11); await buildTree(e.path, kids, depth + 1, undefined, base); applyFilter(); }
+        else if (kids.style.display === 'none') { kids.style.display = ''; ic.innerHTML = icon('chevD', 11); }
+      };
+      ensureExpand.set(e.path, ensure);
+      row.addEventListener('click', async (ev) => {
+        if (ev.altKey) { vscode.postMessage({ type: 'pathToTerminal', path: e.path }); return; } // ⌥-click → send path to terminal
+        select(row);
+        if (kids && kids.style.display !== 'none') { kids.style.display = 'none'; ic.innerHTML = icon('chevR', 11); } // collapse
+        else await ensure();
+      });
+    } else {
+      // Click opens (md→preview, html→browser, …); ⌘-click opens source; ⌥-click → terminal.
+      row.addEventListener('click', (ev) => {
+        if (ev.altKey) { vscode.postMessage({ type: 'pathToTerminal', path: e.path }); return; }
+        select(row); vscode.postMessage({ type: 'open', file: e.path, source: ev.metaKey || ev.ctrlKey });
+      });
+    }
+    return row;
+  }
+
   // ── the tree — lazy: a folder lists its children only on first expand ──
-  async function buildTree(absDir, container, depth, skip, base) {
+  async function buildTree(absDir, container, depth, skipName, base) {
+    container.dataset.depth = depth; container.dataset.base = (base || 14); // for in-place re-list
+    if (skipName) container.dataset.skip = skipName; else delete container.dataset.skip;
+    dirContainers.set(absDir, container);
     const entries = await fsList(absDir);
     for (const e of entries) {
-      if (skip && skip(e.name)) continue;
-      const row = el('div', 'xrow' + (e.dir ? ' dir' : '') + (e.git ? ' g' + e.git : '') + (e.name.startsWith('.') ? ' hidden' : ''));
-      row.dataset.path = e.path; // lets live git pushes find + recolor this row
-      row.style.paddingLeft = ((base || 14) + depth * 9) + 'px'; // content nests under its section (tight)
-      const ic = el('span', 'xicon'); ic.innerHTML = e.dir ? icon('chevR', 11) : fileIconSvg(e.name);
-      const nm = el('span', 'xname');
-      const pm = e.dir ? e.name.match(/^(\d+ - )(.+)$/) : null; // dim the "00 - " ordering prefix
-      if (pm) { nm.append(el('span', 'xpre', pm[1]), document.createTextNode(pm[2])); }
-      else nm.textContent = e.dir ? e.name : e.name.replace(/\.md$/i, '');
-      row.append(ic, nm);
-      if (e.git) row.append(e.dir ? el('span', 'gdot') : el('span', 'gst', e.git)); // folders → dot, files → letter
-      container.appendChild(row);
-      attachCtx(row, e.path);
-      attachDrag(row, e.path);
-      if (e.dir) {
-        let kids = null;
-        const guideX = ((base || 14) + depth * 9 + 7) + 'px'; // child guide line under this chevron
-        const ensure = async () => { // expand-only (used by click + auto-reveal)
-          if (!kids) { kids = el('div', 'xkids'); kids.style.setProperty('--g', guideX); row.after(kids); ic.innerHTML = icon('chevD', 11); await buildTree(e.path, kids, depth + 1, undefined, base); applyFilter(); }
-          else if (kids.style.display === 'none') { kids.style.display = ''; ic.innerHTML = icon('chevD', 11); }
-        };
-        ensureExpand.set(e.path, ensure);
-        row.addEventListener('click', async (ev) => {
-          if (ev.altKey) { vscode.postMessage({ type: 'pathToTerminal', path: e.path }); return; } // ⌥-click → send path to terminal
-          select(row);
-          if (kids && kids.style.display !== 'none') { kids.style.display = 'none'; ic.innerHTML = icon('chevR', 11); } // collapse
-          else await ensure();
-        });
-      } else {
-        // Click opens (md→preview, html→browser, …); ⌘-click opens source; ⌥-click → terminal.
-        row.addEventListener('click', (ev) => {
-          if (ev.altKey) { vscode.postMessage({ type: 'pathToTerminal', path: e.path }); return; }
-          select(row); vscode.postMessage({ type: 'open', file: e.path, source: ev.metaKey || ev.ctrlKey });
-        });
-      }
+      if (skipName && e.name === skipName) continue;
+      container.appendChild(makeRow(e, depth, base));
     }
+  }
+
+  // ── targeted in-place re-list of ONE folder (the IDE-style auto-update) ──
+  // Add rows for new files, drop rows for removed ones, leave every other row +
+  // all expansion untouched → no full repaint, no flicker. No-op when the folder
+  // isn't currently rendered + visible, so writes in collapsed/hidden dirs cost nothing.
+  async function relistFolder(dir) {
+    const container = dirContainers.get(dir);
+    if (!container || container.offsetParent === null) return; // not rendered / collapsed / hidden
+    const depth = +(container.dataset.depth || 0);
+    const base = +(container.dataset.base || 14);
+    const skipName = container.dataset.skip;
+    const entries = (await fsList(dir)).filter((e) => !(skipName && e.name === skipName));
+    const want = new Set(entries.map((e) => e.path));
+    const rowsNow = () => [...container.children].filter((n) => n.classList && n.classList.contains('xrow'));
+    for (const r of rowsNow()) { // drop rows whose file is gone (+ its kids container)
+      if (!want.has(r.dataset.path)) { const k = r.nextElementSibling; if (k && k.classList.contains('xkids')) k.remove(); r.remove(); }
+    }
+    let prev = null; // insert any missing rows in listing order
+    for (const e of entries) {
+      let row = rowsNow().find((r) => r.dataset.path === e.path);
+      if (!row) { row = makeRow(e, depth, base); if (prev) prev.after(row); else container.prepend(row); }
+      prev = (row.nextElementSibling && row.nextElementSibling.classList.contains('xkids')) ? row.nextElementSibling : row;
+    }
+    applyFilter();
   }
 
   // ── collapsible sections (state persisted in webview state) ──
@@ -252,6 +299,7 @@
   async function paintExplorer() {
     explorerEl.replaceChildren();
     ensureExpand.clear();
+    dirContainers.clear();
     const framework = places.find((p) => p.id === 'infra');
     const vault = places.find((p) => p.id === 'vault');
     const workspace = places.filter((p) => p.id === 'workspace');
@@ -259,7 +307,7 @@
     // AIOS — the framework itself: Framework + Vault, nested under one collapsible mark.
     await addGroup('AIOS', { mark: true, label: 'AIOS' }, async (g) => {
       if (framework && (!vault || framework.path !== vault.path)) {
-        await addSection('FRAMEWORK', { dot: 'ring', sub: 'AIOS infra' }, (box) => buildTree(framework.path, box, 0, (n) => n === "vault", 14), g);
+        await addSection('FRAMEWORK', { dot: 'ring', sub: 'AIOS infra' }, (box) => buildTree(framework.path, box, 0, "vault", 14), g);
       }
       if (vault) {
         await addSection('VAULT', { dot: 'solid', sub: 'your notes', primary: true }, (box) => buildTree(vault.path, box, 0, null, 14), g);
@@ -324,6 +372,25 @@
         const ic = row.querySelector('.xicon'); if (ic) ic.innerHTML = icon('chevR', 11);
       }
     });
+  }
+
+  // ── refresh: re-read the tree (pick up new/removed files) while keeping the SAME
+  //    folders expanded + the same row selected. The tree is lazy and out-of-workspace
+  //    watchers are unreliable, so this is how added files surface (button + on-focus). ──
+  let refreshing = false;
+  async function refreshTree() {
+    if (refreshing || !places.length) return; // skip overlap + the pre-paint initial load
+    refreshing = true;
+    try {
+      const open = [...explorerEl.querySelectorAll('.xrow.dir[data-path]')]
+        .filter((r) => { const n = r.nextElementSibling; return n && n.classList.contains('xkids') && n.style.display !== 'none'; })
+        .map((r) => r.dataset.path);
+      const sel = explorerEl.querySelector('.xrow.sel')?.dataset.path;
+      await paintExplorer();
+      // re-expand shallow→deep so each parent registers its children's ensure first
+      for (const p of open.sort((a, b) => a.split('/').length - b.split('/').length)) { const fn = ensureExpand.get(p); if (fn) await fn(); }
+      if (sel) { const r = findRow(sel); if (r) select(r); }
+    } finally { refreshing = false; }
   }
 
   // ── filter: show rows whose name matches + their ancestors ──
@@ -393,8 +460,15 @@
 
   window.addEventListener('message', (e) => {
     const msg = e.data;
-    if (msg.type === 'listing') { const r = pending.get(msg.reqId); if (r) { pending.delete(msg.reqId); r(msg.entries || []); } }
-    else if (msg.type === 'roots') { if (msg.theme) applyTheme(msg.theme); applyHints(msg.hints); if (msg.iconsEnhanced != null) iconsEnhanced = msg.iconsEnhanced; places = msg.places || []; void paintExplorer(); }
+    if (msg.type === 'listing') { const r = pending.get(msg.reqId); if (r) r(msg.entries || []); } // r() deletes from pending
+    else if (msg.type === 'roots') {
+      if (msg.theme) applyTheme(msg.theme); applyHints(msg.hints);
+      if (msg.iconsEnhanced != null) iconsEnhanced = msg.iconsEnhanced;
+      places = msg.places || [];
+      // Await the repaint, then reveal a just-added folder (msg.focus) — expands the
+      // WORKSPACE group to it + selects it, so adding a folder gives instant feedback.
+      paintExplorer().then(() => { if (msg.focus) void revealPath(msg.focus); });
+    }
     else if (msg.type === 'theme') { applyTheme(msg.theme); }
     else if (msg.type === 'hints') { applyHints(msg.show); }
     else if (msg.type === 'icons') { iconsEnhanced = !!msg.enhanced; void paintExplorer(); }
@@ -402,6 +476,8 @@
     else if (msg.type === 'reload') { void paintExplorer(); }
     else if (msg.type === 'revealPath') { void revealPath(msg.path); }
     else if (msg.type === 'collapseAll') { collapseAll(); }
+    else if (msg.type === 'refresh') { void refreshTree(); }
+    else if (msg.type === 'relist') { for (const d of (msg.dirs || [])) void relistFolder(d); } // targeted auto-update
   });
 
   vscode.postMessage({ type: 'ready' });

--- a/media/home.js
+++ b/media/home.js
@@ -33,17 +33,15 @@
   });
 
   // Theme toggle (dark ⇄ light) — the source of truth is the aiosGlass.theme
-  // setting (shared with the Files explorer), but we apply optimistically on click
-  // so the flip is instant, then persist via the extension. The initial class is
-  // injected into <body> at render time (no dark→light flash on open).
+  // setting (shared with the Files explorer). We DON'T flip optimistically — the
+  // toggle may prompt (Glass-only vs Glass + IDE) when off an AIOS theme, so nothing
+  // should change until you choose. The extension persists the result and re-posts the
+  // theme, which flips the canvas here. Initial class is injected at render (no flash).
   const themeBtn = document.getElementById('themeToggle');
-  // Theme is always-active (CSS keeps #themeToggle accent); the icon swaps to show
-  // the current mode. So this just flips the canvas.
   function applyTheme(t){ document.body.classList.toggle('light', t === 'light'); }
   if (themeBtn) themeBtn.addEventListener('click', () => {
     const next = document.body.classList.contains('light') ? 'dark' : 'light';
-    applyTheme(next);
-    vscode.postMessage({ type: 'setTheme', theme: next });
+    vscode.postMessage({ type: 'setTheme', theme: next }); // extension decides + drives the flip
   });
 
   // Collapsible cards — click a title to fold/unfold; persisted in webview state.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aios-glass",
   "displayName": "AIOS Glass",
   "description": "A friendly glass layer over the AIOS — run rituals, browse agents, manage spaces, all from inside Antigravity. Glass, not engine.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "the-aios",
   "license": "GPL-2.0-or-later",
   "repository": {
@@ -30,6 +30,18 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "themes": [
+      {
+        "label": "AIOS Dark",
+        "uiTheme": "vs-dark",
+        "path": "./themes/aios-dark-color-theme.json"
+      },
+      {
+        "label": "AIOS Light",
+        "uiTheme": "vs",
+        "path": "./themes/aios-light-color-theme.json"
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {
@@ -96,6 +108,11 @@
         "command": "aios.filesCollapseAll",
         "title": "AIOS: Collapse Explorer",
         "icon": "$(collapse-all)"
+      },
+      {
+        "command": "aios.filesRefresh",
+        "title": "AIOS: Refresh Explorer",
+        "icon": "$(refresh)"
       },
       {
         "command": "aios.openConfigMenu",
@@ -310,9 +327,14 @@
           "group": "navigation@1"
         },
         {
-          "command": "aios.filesCollapseAll",
+          "command": "aios.filesRefresh",
           "when": "view == aios.files",
           "group": "navigation@0"
+        },
+        {
+          "command": "aios.filesCollapseAll",
+          "when": "view == aios.files",
+          "group": "navigation@1"
         }
       ],
       "commandPalette": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ import { Agent, discoverAgents, iconForAgent } from './agents/agents';
 import { Capability, skillsPicker, discoverSkills } from './capabilities/capabilities';
 import { companyAction, collaborateAction } from './spaces/spacesActions';
 import { openConfigMenu } from './home/configMenu';
-import { TERMINAL_OPTIONS, setTerminalMode } from './home/config';
+import { TERMINAL_OPTIONS, setTerminalMode, syncGlassToWorkbench } from './home/config';
 import { createCustom, CreateKind, CREATE_KINDS } from './create/create';
 import { listRunningAgents } from './agents/running';
 import { swallow, logChannel, log } from './log';
@@ -63,6 +63,7 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('aios.openFiles', () =>
       FilesViewProvider.current ? FilesViewProvider.current.toggle() : vscode.commands.executeCommand('aios.files.focus')),
     vscode.commands.registerCommand('aios.filesCollapseAll', () => FilesViewProvider.current?.collapseAll()),
+    vscode.commands.registerCommand('aios.filesRefresh', () => FilesViewProvider.current?.refresh()),
 
     vscode.commands.registerCommand('aios.companyAction', (name?: string) => companyAction(name)),
     vscode.commands.registerCommand('aios.collaborateAction', () => collaborateAction()),
@@ -469,6 +470,8 @@ export function activate(context: vscode.ExtensionContext): void {
 
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration('aiosGlass.frameworkPath') || e.affectsConfiguration('aiosGlass.showHints') || e.affectsConfiguration('aiosGlass.showNudges') || e.affectsConfiguration('aiosGlass.theme') || e.affectsConfiguration('aiosGlass.showMemory')) HomeViewProvider.current?.refresh();
+      // Editor theme changed (⌘K⌘T or OS auto-detect) → if it's an AIOS theme, flip Glass to match.
+      if (e.affectsConfiguration('workbench.colorTheme')) void syncGlassToWorkbench();
     })
   );
 

--- a/src/files/filesView.ts
+++ b/src/files/filesView.ts
@@ -41,6 +41,8 @@ export class FilesViewProvider implements vscode.WebviewViewProvider {
   private disposables: vscode.Disposable[] = [];
   private gitTimer?: ReturnType<typeof setTimeout>;
   private gitPoll?: ReturnType<typeof setInterval>;
+  private relistTimer?: ReturnType<typeof setTimeout>;
+  private relistDirs = new Set<string>();
   // basename → fsPath for markdown previews we opened — lets auto-reveal follow a
   // preview tab back to its file (preview webviews expose no uri of their own).
   private previewPaths = new Map<string, string>();
@@ -91,6 +93,7 @@ export class FilesViewProvider implements vscode.WebviewViewProvider {
     this.gitPoll = setInterval(() => { if (this.isVisible()) this.pushGit(); }, 3000);
     webviewView.onDidDispose(() => {
       if (this.gitPoll) { clearInterval(this.gitPoll); this.gitPoll = undefined; }
+      if (this.relistTimer) { clearTimeout(this.relistTimer); this.relistTimer = undefined; }
       while (this.disposables.length) try { this.disposables.pop()?.dispose(); } catch { /* ignore */ }
       while (this.gitWatchers.length) try { this.gitWatchers.pop()?.dispose(); } catch { /* ignore */ }
     });
@@ -105,9 +108,13 @@ export class FilesViewProvider implements vscode.WebviewViewProvider {
     while (this.gitWatchers.length) { try { this.gitWatchers.pop()?.dispose(); } catch { /* ignore */ } }
     const repos = new Set<string>();
     const fire = () => this.scheduleGit();
+    // create/delete change the tree's SHAPE — also queue a TARGETED re-list of just the
+    // changed file's parent folder (the webview no-ops unless that folder is visible),
+    // so a new file surfaces on its own without a full repaint. Plain change = git only.
+    const fireStructural = (u: vscode.Uri) => { this.scheduleGit(); this.scheduleRelist(u); };
     for (const pl of this.places()) {
       const w = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(vscode.Uri.file(pl.path), '**/*'));
-      w.onDidChange(fire); w.onDidCreate(fire); w.onDidDelete(fire);
+      w.onDidChange(fire); w.onDidCreate(fireStructural); w.onDidDelete(fireStructural);
       this.gitWatchers.push(w);
       const r = this.repoRoot(pl.path);
       if (r) repos.add(r);
@@ -122,6 +129,18 @@ export class FilesViewProvider implements vscode.WebviewViewProvider {
   private scheduleGit(delay = 350): void {
     if (this.gitTimer) clearTimeout(this.gitTimer);
     this.gitTimer = setTimeout(() => this.pushGit(), delay);
+  }
+
+  /** Debounced, parent-dir-scoped re-list. Coalesces a burst (a build / git checkout
+   *  writing many files) into one message carrying the unique changed folders; the
+   *  webview re-lists only those that are actually rendered. Cheap — no full repaint. */
+  private scheduleRelist(uri: vscode.Uri): void {
+    this.relistDirs.add(path.dirname(uri.fsPath));
+    if (this.relistTimer) clearTimeout(this.relistTimer);
+    this.relistTimer = setTimeout(() => {
+      const dirs = [...this.relistDirs]; this.relistDirs.clear();
+      this.post({ type: 'relist', dirs });
+    }, 300);
   }
 
   private repoListCache = new Map<string, { at: number; repos: string[] }>();
@@ -185,6 +204,11 @@ export class FilesViewProvider implements vscode.WebviewViewProvider {
 
   /** Collapse the tree to the top (the ⊟ title-bar action). */
   collapseAll(): void { this.post({ type: 'collapseAll' }); }
+
+  /** Full re-read preserving expansion (the ⟳ title-bar action) — the manual catch-all.
+   *  Automatic updates happen in place via scheduleRelist (per-folder, no repaint); this
+   *  is the heavier "rebuild everything" fallback for when you just want a clean re-read. */
+  refresh(): void { this.post({ type: 'refresh' }); }
 
   /** Open the Files view if hidden; hide it if shown. VS Code can't say which bar a
    *  view sits in, so we probe. Files lives in the PRIMARY sidebar by default (its own

--- a/src/home/config.ts
+++ b/src/home/config.ts
@@ -177,8 +177,69 @@ export function currentTheme(): 'dark' | 'light' {
   return vscode.workspace.getConfiguration('aiosGlass').get<string>('theme', 'dark') === 'light' ? 'light' : 'dark';
 }
 
+/** The bundled workbench theme names, keyed by Glass mode. */
+export const AIOS_WORKBENCH_THEME = { dark: 'AIOS Dark', light: 'AIOS Light' } as const;
+
+/** The active VS Code workbench (editor) color theme. */
+export function workbenchThemeName(): string {
+  return vscode.workspace.getConfiguration('workbench').get<string>('colorTheme', '') || '';
+}
+
+/** Is the editor already on one of the AIOS workbench themes? (Gates the co-switch —
+ *  we only ever touch the editor theme when the operator has opted into AIOS by
+ *  selecting it; a personal theme like GitHub Dark / Tokyo Night is never hijacked.) */
+export function isAiosWorkbenchTheme(): boolean {
+  const t = workbenchThemeName();
+  return t === AIOS_WORKBENCH_THEME.dark || t === AIOS_WORKBENCH_THEME.light;
+}
+
 export async function setTheme(value: 'dark' | 'light'): Promise<void> {
   await vscode.workspace.getConfiguration('aiosGlass').update('theme', value, vscode.ConfigurationTarget.Global);
+  // Smart co-switch: move the EDITOR theme to match ONLY if it's already an AIOS theme.
+  // Idempotent (skips a no-op write), so the reverse listener can't loop.
+  if (isAiosWorkbenchTheme()) {
+    const want = AIOS_WORKBENCH_THEME[value];
+    if (workbenchThemeName() !== want) {
+      await vscode.workspace.getConfiguration('workbench').update('colorTheme', want, vscode.ConfigurationTarget.Global);
+    }
+  }
+}
+
+/** Explicit "move into the AIOS theme" — sets BOTH Glass panels and the editor theme.
+ *  This is the opt-in entry point (cog → Theme → AIOS Dark/Light); once the editor is
+ *  on an AIOS theme, every later Glass flip co-switches it automatically. */
+export async function setAiosTheme(value: 'dark' | 'light'): Promise<void> {
+  await vscode.workspace.getConfiguration('aiosGlass').update('theme', value, vscode.ConfigurationTarget.Global);
+  await vscode.workspace.getConfiguration('workbench').update('colorTheme', AIOS_WORKBENCH_THEME[value], vscode.ConfigurationTarget.Global);
+  void vscode.window.showInformationMessage(`AIOS Glass: ${AIOS_WORKBENCH_THEME[value]} applied — Glass + IDE in lockstep.`);
+}
+
+/** The header sun/moon toggle.
+ *  - On an AIOS theme → co-switch Glass + IDE, no prompt (you're clearly in AIOS).
+ *  - On any other IDE theme → ALWAYS ask: Glass only, or switch the whole IDE to AIOS?
+ *    No sticky memory — each toggle is a fresh choice, so you're never trapped in one mode
+ *    (and the moment you pick Glass + IDE you're on AIOS, so it stops asking). */
+export async function toggleTheme(mode: 'dark' | 'light'): Promise<void> {
+  if (isAiosWorkbenchTheme()) { await setTheme(mode); return; } // co-switch handles the IDE
+  const pick = await vscode.window.showQuickPick(
+    [
+      { label: '$(paintcan) Glass only', description: 'just the AIOS panels — keep your IDE theme', full: false },
+      { label: '$(color-mode) Glass + IDE', description: 'switch the whole IDE with Glass (AIOS themes)', full: true }
+    ],
+    { title: 'Theme toggle — what should it switch?', placeHolder: 'Asked while your IDE is on a non-AIOS theme · pick Glass + IDE to stop asking' }
+  );
+  if (!pick) return; // cancelled → change nothing (the webview no longer flips optimistically)
+  if (pick.full) await setAiosTheme(mode); else await setTheme(mode);
+}
+
+/** Reverse sync: when the editor theme becomes AIOS Dark/Light (picked via ⌘K⌘T or OS
+ *  auto-detect), flip Glass panels to match. No-op for any non-AIOS theme, and skips a
+ *  no-op write so it can't loop with setTheme's co-switch. Called from the config listener. */
+export async function syncGlassToWorkbench(): Promise<void> {
+  const t = workbenchThemeName();
+  const mode = t === AIOS_WORKBENCH_THEME.dark ? 'dark' : t === AIOS_WORKBENCH_THEME.light ? 'light' : undefined;
+  if (!mode || currentTheme() === mode) return;
+  await vscode.workspace.getConfiguration('aiosGlass').update('theme', mode, vscode.ConfigurationTarget.Global);
 }
 
 /** Whether to show the contextual ritual nudge banner (morning/daytime/evening). Default true. */

--- a/src/home/configMenu.ts
+++ b/src/home/configMenu.ts
@@ -9,7 +9,7 @@ import {
   showHints, setShowHints,
   showNudges, setShowNudges,
   nativeTabsEnabled, setNativeTabs,
-  currentTheme, setTheme,
+  currentTheme, setTheme, setAiosTheme, isAiosWorkbenchTheme,
   fileIconsEnhanced, setFileIcons,
   showHiddenFiles, setShowHidden,
   autoReveal, setAutoReveal,
@@ -25,7 +25,7 @@ export async function openConfigMenu(): Promise<void> {
   const items: (vscode.QuickPickItem & { id?: string })[] = [
     // ── Appearance — how the Glass surfaces look ──
     sep('Appearance'),
-    { label: '$(color-mode) Theme', description: currentTheme(), id: 'theme' },
+    { label: '$(color-mode) Theme (Glass + IDE)', description: isAiosWorkbenchTheme() ? `${currentTheme()} · IDE synced` : `Glass: ${currentTheme()}`, id: 'theme' },
     { label: '$(eye) Secondary hints', description: showHints() ? 'on' : 'off', id: 'hints' },
     { label: '$(bell) Ritual nudges', description: showNudges() ? 'on' : 'off', id: 'nudges' },
     { label: '$(pulse) Session memory', description: showMemory() ? 'shown' : 'hidden', id: 'memory' },
@@ -69,14 +69,17 @@ export async function openConfigMenu(): Promise<void> {
       await vscode.commands.executeCommand('aios.showLogs');
       return;
     case 'theme': {
+      const onAios = isAiosWorkbenchTheme();
       const choice = await vscode.window.showQuickPick(
         [
-          { label: '$(circle-filled) Dark', description: 'deep black + coral — the default', value: 'dark' as const },
-          { label: '$(circle-outline) Light', description: 'paper canvas + coral — bright rooms / projectors', value: 'light' as const }
+          { label: '$(circle-filled) AIOS Dark', description: 'Glass + IDE — deep black + coral', mode: 'dark' as const, full: true },
+          { label: '$(circle-outline) AIOS Light', description: 'Glass + IDE — paper canvas + coral', mode: 'light' as const, full: true },
+          { label: '$(paintcan) Glass dark only', description: 'Glass only — keep your IDE theme', mode: 'dark' as const, full: false },
+          { label: '$(paintcan) Glass light only', description: 'Glass only — keep your IDE theme', mode: 'light' as const, full: false }
         ],
-        { title: `Theme — currently ${currentTheme()}`, placeHolder: 'Reskins Home + Files (terminals stay dark)' }
+        { title: `Theme — Glass ${currentTheme()}${onAios ? ' · IDE on AIOS (in lockstep)' : ''}`, placeHolder: 'AIOS = Glass + IDE together · Glass-only leaves your IDE theme alone' }
       );
-      if (choice) await setTheme(choice.value);
+      if (choice) await (choice.full ? setAiosTheme(choice.mode) : setTheme(choice.mode));
       return;
     }
     case 'hidden': {

--- a/src/home/homePanel.ts
+++ b/src/home/homePanel.ts
@@ -15,7 +15,7 @@ import { frequentTaskCount } from '../tasks/frequent';
 import { recentLearnings, nudgeState, observedDirPath, recentOutputs } from '../insights/insights';
 import { recentReports } from '../tasks/reports';
 import { readCompanies, readCollabSpaces, readFrameworkStatus, checkForUpdates } from '../spaces/spaces';
-import { currentTerminalMode, rateLimit, nextAccount, anthropicAccounts, showHints, showNudges, currentTheme, setTheme, showMemory } from './config';
+import { currentTerminalMode, rateLimit, nextAccount, anthropicAccounts, showHints, showNudges, currentTheme, toggleTheme, showMemory } from './config';
 import { getFilesVisible } from '../files/filesState';
 
 /**
@@ -212,9 +212,10 @@ export class HomeViewProvider implements vscode.WebviewViewProvider {
         return;
       case 'setTheme':
         // The webview applied it optimistically; persist to the shared setting so
-        // the Files explorer (and the next open) match. onDidChangeConfiguration
-        // re-posts state to reconcile any surface that didn't flip locally.
-        if (msg.theme === 'dark' || msg.theme === 'light') await setTheme(msg.theme);
+        // the Files explorer (and the next open) match. toggleTheme adds the smart
+        // co-switch / one-time scope prompt; onDidChangeConfiguration re-posts state
+        // to reconcile any surface that didn't flip locally.
+        if (msg.theme === 'dark' || msg.theme === 'light') await toggleTheme(msg.theme);
         return;
       case 'navMonth':
         this.post({ type: 'month', data: getMonthData(msg.year, msg.month) });

--- a/themes/aios-dark-color-theme.json
+++ b/themes/aios-dark-color-theme.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "vscode://schemas/color-theme",
+  "name": "AIOS Dark",
+  "type": "dark",
+  "semanticHighlighting": true,
+  "colors": {
+    "//": "Grounded in the AIOS Glass dark tokens: canvas #0a0a0a, surfaces #111/#181818, line #262626, ink #fafafa, muted #c4c4c4, subtle #707070, accent coral #ff5d4d, ok #5ad19a.",
+    "foreground": "#c4c4c4",
+    "descriptionForeground": "#8a8a8a",
+    "errorForeground": "#d0453a",
+    "focusBorder": "#ff5d4d73",
+    "contrastBorder": "#00000000",
+    "widget.shadow": "#00000066",
+    "selection.background": "#ff5d4d59",
+    "icon.foreground": "#c4c4c4",
+    "sash.hoverBorder": "#ff5d4d99",
+
+    "window.activeBorder": "#0a0a0a",
+    "window.inactiveBorder": "#0a0a0a",
+
+    "editor.background": "#0a0a0a",
+    "editor.foreground": "#e8e8e8",
+    "editorLineNumber.foreground": "#454545",
+    "editorLineNumber.activeForeground": "#ff5d4d",
+    "editorCursor.foreground": "#ff5d4d",
+    "editor.selectionBackground": "#ff5d4d33",
+    "editor.selectionHighlightBackground": "#ff5d4d1f",
+    "editor.inactiveSelectionBackground": "#ff5d4d1a",
+    "editor.wordHighlightBackground": "#ffffff10",
+    "editor.wordHighlightStrongBackground": "#ffffff18",
+    "editor.findMatchBackground": "#ff5d4d66",
+    "editor.findMatchHighlightBackground": "#ff5d4d33",
+    "editor.lineHighlightBackground": "#ffffff08",
+    "editor.lineHighlightBorder": "#00000000",
+    "editorWhitespace.foreground": "#2a2a2a",
+    "editorIndentGuide.background1": "#1c1c1c",
+    "editorIndentGuide.activeBackground1": "#333333",
+    "editorRuler.foreground": "#1c1c1c",
+    "editorBracketMatch.background": "#ff5d4d22",
+    "editorBracketMatch.border": "#ff5d4d66",
+    "editorLink.activeForeground": "#ff5d4d",
+    "editorOverviewRuler.border": "#00000000",
+    "editorGutter.modifiedBackground": "#d4a04a",
+    "editorGutter.addedBackground": "#46a758",
+    "editorGutter.deletedBackground": "#d0453a",
+
+    "editorWidget.background": "#111111",
+    "editorWidget.border": "#262626",
+    "editorSuggestWidget.background": "#111111",
+    "editorSuggestWidget.border": "#262626",
+    "editorSuggestWidget.selectedBackground": "#181818",
+    "editorSuggestWidget.highlightForeground": "#ff5d4d",
+    "editorHoverWidget.background": "#111111",
+    "editorHoverWidget.border": "#262626",
+    "peekViewEditor.background": "#0d0d0d",
+    "peekViewResult.background": "#111111",
+    "peekViewTitle.background": "#111111",
+
+    "input.background": "#111111",
+    "input.foreground": "#e8e8e8",
+    "input.border": "#262626",
+    "input.placeholderForeground": "#707070",
+    "inputOption.activeBorder": "#ff5d4d",
+    "inputOption.activeBackground": "#ff5d4d33",
+    "inputValidation.errorBackground": "#3a1714",
+    "inputValidation.errorBorder": "#d0453a",
+    "dropdown.background": "#111111",
+    "dropdown.border": "#262626",
+    "dropdown.foreground": "#e8e8e8",
+
+    "button.background": "#ff5d4d",
+    "button.foreground": "#0a0a0a",
+    "button.hoverBackground": "#ff7263",
+    "button.secondaryBackground": "#1f1f1f",
+    "button.secondaryForeground": "#e8e8e8",
+    "button.secondaryHoverBackground": "#262626",
+    "badge.background": "#ff5d4d",
+    "badge.foreground": "#0a0a0a",
+    "progressBar.background": "#ff5d4d",
+
+    "activityBar.background": "#0a0a0a",
+    "activityBar.foreground": "#fafafa",
+    "activityBar.inactiveForeground": "#707070",
+    "activityBar.border": "#161616",
+    "activityBar.activeBorder": "#ff5d4d",
+    "activityBarBadge.background": "#ff5d4d",
+    "activityBarBadge.foreground": "#0a0a0a",
+
+    "sideBar.background": "#0c0c0c",
+    "sideBar.foreground": "#c4c4c4",
+    "sideBar.border": "#161616",
+    "sideBarTitle.foreground": "#c4c4c4",
+    "sideBarSectionHeader.background": "#0c0c0c",
+    "sideBarSectionHeader.foreground": "#8a8a8a",
+    "sideBarSectionHeader.border": "#161616",
+
+    "list.activeSelectionBackground": "#1c1c1c",
+    "list.activeSelectionForeground": "#fafafa",
+    "list.inactiveSelectionBackground": "#161616",
+    "list.inactiveSelectionForeground": "#e8e8e8",
+    "list.hoverBackground": "#161616",
+    "list.focusBackground": "#1c1c1c",
+    "list.highlightForeground": "#ff5d4d",
+    "list.errorForeground": "#d0453a",
+    "list.warningForeground": "#d4a04a",
+    "tree.indentGuidesStroke": "#262626",
+
+    "editorGroup.border": "#161616",
+    "editorGroupHeader.tabsBackground": "#0c0c0c",
+    "editorGroupHeader.tabsBorder": "#161616",
+    "editorGroupHeader.noTabsBackground": "#0a0a0a",
+    "tab.activeBackground": "#0a0a0a",
+    "tab.activeForeground": "#fafafa",
+    "tab.activeBorderTop": "#ff5d4d",
+    "tab.activeBorder": "#00000000",
+    "tab.inactiveBackground": "#0c0c0c",
+    "tab.inactiveForeground": "#707070",
+    "tab.border": "#161616",
+    "tab.hoverBackground": "#141414",
+    "tab.unfocusedActiveForeground": "#c4c4c4",
+
+    "titleBar.activeBackground": "#0a0a0a",
+    "titleBar.activeForeground": "#c4c4c4",
+    "titleBar.inactiveBackground": "#0a0a0a",
+    "titleBar.inactiveForeground": "#707070",
+    "titleBar.border": "#161616",
+
+    "statusBar.background": "#0a0a0a",
+    "statusBar.foreground": "#c4c4c4",
+    "statusBar.border": "#161616",
+    "statusBar.noFolderBackground": "#0a0a0a",
+    "statusBar.debuggingBackground": "#ff5d4d",
+    "statusBar.debuggingForeground": "#0a0a0a",
+    "statusBarItem.remoteBackground": "#ff5d4d",
+    "statusBarItem.remoteForeground": "#0a0a0a",
+    "statusBarItem.hoverBackground": "#ffffff14",
+    "statusBarItem.prominentBackground": "#1f1f1f",
+
+    "panel.background": "#0a0a0a",
+    "panel.border": "#262626",
+    "panelTitle.activeForeground": "#fafafa",
+    "panelTitle.inactiveForeground": "#707070",
+    "panelTitle.activeBorder": "#ff5d4d",
+    "panelInput.border": "#262626",
+
+    "terminal.background": "#0a0a0a",
+    "terminal.foreground": "#d4d4d4",
+    "terminalCursor.foreground": "#ff5d4d",
+    "terminalCursor.background": "#0a0a0a",
+    "terminal.selectionBackground": "#ff5d4d33",
+    "terminal.border": "#262626",
+    "terminal.ansiBlack": "#1f1f1f",
+    "terminal.ansiBrightBlack": "#707070",
+    "terminal.ansiRed": "#d0453a",
+    "terminal.ansiBrightRed": "#ff5d4d",
+    "terminal.ansiGreen": "#46a758",
+    "terminal.ansiBrightGreen": "#5ad19a",
+    "terminal.ansiYellow": "#d4a04a",
+    "terminal.ansiBrightYellow": "#caa92a",
+    "terminal.ansiBlue": "#4aa3ff",
+    "terminal.ansiBrightBlue": "#42a5f5",
+    "terminal.ansiMagenta": "#c586ff",
+    "terminal.ansiBrightMagenta": "#d9a8ff",
+    "terminal.ansiCyan": "#41c4d8",
+    "terminal.ansiBrightCyan": "#5fd3e4",
+    "terminal.ansiWhite": "#c4c4c4",
+    "terminal.ansiBrightWhite": "#fafafa",
+
+    "scrollbar.shadow": "#00000000",
+    "scrollbarSlider.background": "#ffffff14",
+    "scrollbarSlider.hoverBackground": "#ffffff24",
+    "scrollbarSlider.activeBackground": "#ffffff33",
+    "minimap.background": "#0a0a0a",
+
+    "breadcrumb.foreground": "#707070",
+    "breadcrumb.focusForeground": "#c4c4c4",
+    "breadcrumb.background": "#0a0a0a",
+
+    "gitDecoration.modifiedResourceForeground": "#d4a04a",
+    "gitDecoration.untrackedResourceForeground": "#46a758",
+    "gitDecoration.addedResourceForeground": "#46a758",
+    "gitDecoration.deletedResourceForeground": "#d0453a",
+    "gitDecoration.ignoredResourceForeground": "#4a4a4a",
+    "gitDecoration.conflictingResourceForeground": "#ff5d4d",
+
+    "notifications.background": "#111111",
+    "notifications.border": "#262626",
+    "notificationCenterHeader.background": "#0c0c0c",
+    "notificationsErrorIcon.foreground": "#d0453a",
+    "notificationsWarningIcon.foreground": "#d4a04a",
+    "notificationsInfoIcon.foreground": "#42a5f5",
+
+    "menu.background": "#111111",
+    "menu.foreground": "#e8e8e8",
+    "menu.border": "#262626",
+    "menu.selectionBackground": "#1f1f1f",
+    "menu.selectionForeground": "#fafafa",
+    "menubar.selectionBackground": "#1f1f1f",
+
+    "pickerGroup.foreground": "#ff5d4d",
+    "pickerGroup.border": "#262626",
+    "quickInput.background": "#111111",
+    "quickInputList.focusBackground": "#1f1f1f",
+
+    "textLink.foreground": "#ff7263",
+    "textLink.activeForeground": "#ff5d4d",
+    "textCodeBlock.background": "#161616",
+    "textPreformat.foreground": "#5ad19a"
+  },
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment", "string.comment"],
+      "settings": { "foreground": "#6f6f6f", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["string", "string.quoted", "string.template", "punctuation.definition.string"],
+      "settings": { "foreground": "#5ad19a" }
+    },
+    {
+      "scope": ["constant.numeric", "constant.language", "constant.character", "constant.other"],
+      "settings": { "foreground": "#d4a04a" }
+    },
+    {
+      "scope": ["keyword", "keyword.control", "storage", "storage.type", "storage.modifier", "keyword.operator.new"],
+      "settings": { "foreground": "#ff5d4d" }
+    },
+    {
+      "scope": ["keyword.operator"],
+      "settings": { "foreground": "#cfcfcf" }
+    },
+    {
+      "scope": ["entity.name.function", "support.function", "meta.function-call.generic"],
+      "settings": { "foreground": "#42a5f5" }
+    },
+    {
+      "scope": ["entity.name.type", "entity.name.class", "support.type", "support.class", "entity.other.inherited-class"],
+      "settings": { "foreground": "#41c4d8" }
+    },
+    {
+      "scope": ["variable", "variable.other", "meta.definition.variable.name", "support.variable"],
+      "settings": { "foreground": "#e8e8e8" }
+    },
+    {
+      "scope": ["variable.parameter"],
+      "settings": { "foreground": "#d0c8b0" }
+    },
+    {
+      "scope": ["variable.language", "variable.language.this"],
+      "settings": { "foreground": "#ff8a7d", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["variable.other.property", "support.variable.property", "meta.object-literal.key"],
+      "settings": { "foreground": "#9ad0ff" }
+    },
+    {
+      "scope": ["entity.name.tag", "punctuation.definition.tag"],
+      "settings": { "foreground": "#ff5d4d" }
+    },
+    {
+      "scope": ["entity.other.attribute-name"],
+      "settings": { "foreground": "#d4a04a" }
+    },
+    {
+      "scope": ["support.type.property-name.css", "entity.name.tag.css"],
+      "settings": { "foreground": "#4aa3ff" }
+    },
+    {
+      "scope": ["markup.heading", "entity.name.section.markdown", "markup.heading.markdown"],
+      "settings": { "foreground": "#ff5d4d", "fontStyle": "bold" }
+    },
+    {
+      "scope": ["markup.bold"],
+      "settings": { "foreground": "#fafafa", "fontStyle": "bold" }
+    },
+    {
+      "scope": ["markup.italic"],
+      "settings": { "fontStyle": "italic" }
+    },
+    {
+      "scope": ["markup.inline.raw", "markup.fenced_code", "markup.raw.markdown"],
+      "settings": { "foreground": "#5ad19a" }
+    },
+    {
+      "scope": ["markup.underline.link", "string.other.link"],
+      "settings": { "foreground": "#42a5f5" }
+    },
+    {
+      "scope": ["entity.name.tag.yaml", "punctuation.support.type.property-name"],
+      "settings": { "foreground": "#9ad0ff" }
+    },
+    {
+      "scope": ["support.type.property-name.json"],
+      "settings": { "foreground": "#9ad0ff" }
+    },
+    {
+      "scope": ["invalid", "invalid.illegal"],
+      "settings": { "foreground": "#d0453a" }
+    },
+    {
+      "scope": ["token.info-token"],
+      "settings": { "foreground": "#42a5f5" }
+    },
+    {
+      "scope": ["token.warn-token"],
+      "settings": { "foreground": "#d4a04a" }
+    },
+    {
+      "scope": ["token.error-token"],
+      "settings": { "foreground": "#d0453a" }
+    }
+  ]
+}

--- a/themes/aios-light-color-theme.json
+++ b/themes/aios-light-color-theme.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "vscode://schemas/color-theme",
+  "name": "AIOS Light",
+  "type": "light",
+  "semanticHighlighting": true,
+  "colors": {
+    "//": "Grounded in the AIOS Glass light tokens: canvas #f7f7f5, surfaces #fff/#f1f1ee/#e9e9e4, line #e3e3dd, ink #0c0c0d, muted #52525b, subtle #8a8a90, accent coral #ff5d4d, accent-soft (legible coral text) #d6402c, ok #1f9d57.",
+    "foreground": "#52525b",
+    "descriptionForeground": "#8a8a90",
+    "errorForeground": "#c0392b",
+    "focusBorder": "#d6402c80",
+    "contrastBorder": "#00000000",
+    "widget.shadow": "#0f0f1422",
+    "selection.background": "#ff5d4d4d",
+    "icon.foreground": "#52525b",
+    "sash.hoverBorder": "#d6402c99",
+
+    "window.activeBorder": "#f7f7f5",
+    "window.inactiveBorder": "#f7f7f5",
+
+    "editor.background": "#f7f7f5",
+    "editor.foreground": "#1c1c1f",
+    "editorLineNumber.foreground": "#bdbdb6",
+    "editorLineNumber.activeForeground": "#d6402c",
+    "editorCursor.foreground": "#ff5d4d",
+    "editor.selectionBackground": "#ff5d4d3d",
+    "editor.selectionHighlightBackground": "#ff5d4d24",
+    "editor.inactiveSelectionBackground": "#ff5d4d1f",
+    "editor.wordHighlightBackground": "#00000010",
+    "editor.wordHighlightStrongBackground": "#00000016",
+    "editor.findMatchBackground": "#ff5d4d80",
+    "editor.findMatchHighlightBackground": "#ff5d4d3d",
+    "editor.lineHighlightBackground": "#00000006",
+    "editor.lineHighlightBorder": "#00000000",
+    "editorWhitespace.foreground": "#dcdcd5",
+    "editorIndentGuide.background1": "#e9e9e4",
+    "editorIndentGuide.activeBackground1": "#cfcfc8",
+    "editorRuler.foreground": "#e9e9e4",
+    "editorBracketMatch.background": "#ff5d4d24",
+    "editorBracketMatch.border": "#d6402c80",
+    "editorLink.activeForeground": "#d6402c",
+    "editorOverviewRuler.border": "#00000000",
+    "editorGutter.modifiedBackground": "#b07814",
+    "editorGutter.addedBackground": "#1f9d57",
+    "editorGutter.deletedBackground": "#c0392b",
+
+    "editorWidget.background": "#ffffff",
+    "editorWidget.border": "#e3e3dd",
+    "editorSuggestWidget.background": "#ffffff",
+    "editorSuggestWidget.border": "#e3e3dd",
+    "editorSuggestWidget.selectedBackground": "#e9e9e4",
+    "editorSuggestWidget.highlightForeground": "#d6402c",
+    "editorHoverWidget.background": "#ffffff",
+    "editorHoverWidget.border": "#e3e3dd",
+    "peekViewEditor.background": "#f1f1ee",
+    "peekViewResult.background": "#ffffff",
+    "peekViewTitle.background": "#ffffff",
+
+    "input.background": "#ffffff",
+    "input.foreground": "#0c0c0d",
+    "input.border": "#e3e3dd",
+    "input.placeholderForeground": "#8a8a90",
+    "inputOption.activeBorder": "#ff5d4d",
+    "inputOption.activeBackground": "#ff5d4d33",
+    "inputValidation.errorBackground": "#fbe7e4",
+    "inputValidation.errorBorder": "#c0392b",
+    "dropdown.background": "#ffffff",
+    "dropdown.border": "#e3e3dd",
+    "dropdown.foreground": "#0c0c0d",
+
+    "button.background": "#ff5d4d",
+    "button.foreground": "#ffffff",
+    "button.hoverBackground": "#d6402c",
+    "button.secondaryBackground": "#e9e9e4",
+    "button.secondaryForeground": "#0c0c0d",
+    "button.secondaryHoverBackground": "#dedeD7",
+    "badge.background": "#ff5d4d",
+    "badge.foreground": "#ffffff",
+    "progressBar.background": "#ff5d4d",
+
+    "activityBar.background": "#f1f1ee",
+    "activityBar.foreground": "#0c0c0d",
+    "activityBar.inactiveForeground": "#8a8a90",
+    "activityBar.border": "#e3e3dd",
+    "activityBar.activeBorder": "#ff5d4d",
+    "activityBarBadge.background": "#ff5d4d",
+    "activityBarBadge.foreground": "#ffffff",
+
+    "sideBar.background": "#f7f7f5",
+    "sideBar.foreground": "#52525b",
+    "sideBar.border": "#e3e3dd",
+    "sideBarTitle.foreground": "#52525b",
+    "sideBarSectionHeader.background": "#f7f7f5",
+    "sideBarSectionHeader.foreground": "#8a8a90",
+    "sideBarSectionHeader.border": "#e3e3dd",
+
+    "list.activeSelectionBackground": "#e9e9e4",
+    "list.activeSelectionForeground": "#0c0c0d",
+    "list.inactiveSelectionBackground": "#eeeeea",
+    "list.inactiveSelectionForeground": "#0c0c0d",
+    "list.hoverBackground": "#efefec",
+    "list.focusBackground": "#e9e9e4",
+    "list.highlightForeground": "#d6402c",
+    "list.errorForeground": "#c0392b",
+    "list.warningForeground": "#b07814",
+    "tree.indentGuidesStroke": "#e3e3dd",
+
+    "editorGroup.border": "#e3e3dd",
+    "editorGroupHeader.tabsBackground": "#f1f1ee",
+    "editorGroupHeader.tabsBorder": "#e3e3dd",
+    "editorGroupHeader.noTabsBackground": "#f7f7f5",
+    "tab.activeBackground": "#f7f7f5",
+    "tab.activeForeground": "#0c0c0d",
+    "tab.activeBorderTop": "#ff5d4d",
+    "tab.activeBorder": "#00000000",
+    "tab.inactiveBackground": "#f1f1ee",
+    "tab.inactiveForeground": "#8a8a90",
+    "tab.border": "#e3e3dd",
+    "tab.hoverBackground": "#eeeeea",
+    "tab.unfocusedActiveForeground": "#52525b",
+
+    "titleBar.activeBackground": "#f1f1ee",
+    "titleBar.activeForeground": "#52525b",
+    "titleBar.inactiveBackground": "#f1f1ee",
+    "titleBar.inactiveForeground": "#8a8a90",
+    "titleBar.border": "#e3e3dd",
+
+    "statusBar.background": "#f1f1ee",
+    "statusBar.foreground": "#52525b",
+    "statusBar.border": "#e3e3dd",
+    "statusBar.noFolderBackground": "#f1f1ee",
+    "statusBar.debuggingBackground": "#ff5d4d",
+    "statusBar.debuggingForeground": "#ffffff",
+    "statusBarItem.remoteBackground": "#ff5d4d",
+    "statusBarItem.remoteForeground": "#ffffff",
+    "statusBarItem.hoverBackground": "#00000010",
+    "statusBarItem.prominentBackground": "#e9e9e4",
+
+    "panel.background": "#f7f7f5",
+    "panel.border": "#e3e3dd",
+    "panelTitle.activeForeground": "#0c0c0d",
+    "panelTitle.inactiveForeground": "#8a8a90",
+    "panelTitle.activeBorder": "#ff5d4d",
+    "panelInput.border": "#e3e3dd",
+
+    "terminal.background": "#f7f7f5",
+    "terminal.foreground": "#2a2a2e",
+    "terminalCursor.foreground": "#ff5d4d",
+    "terminalCursor.background": "#f7f7f5",
+    "terminal.selectionBackground": "#ff5d4d3d",
+    "terminal.border": "#e3e3dd",
+    "terminal.ansiBlack": "#3a3a3a",
+    "terminal.ansiBrightBlack": "#8a8a90",
+    "terminal.ansiRed": "#c0392b",
+    "terminal.ansiBrightRed": "#ff5d4d",
+    "terminal.ansiGreen": "#1f9d57",
+    "terminal.ansiBrightGreen": "#2bb56a",
+    "terminal.ansiYellow": "#b07814",
+    "terminal.ansiBrightYellow": "#caa92a",
+    "terminal.ansiBlue": "#2563b8",
+    "terminal.ansiBrightBlue": "#3b82d6",
+    "terminal.ansiMagenta": "#7c3aed",
+    "terminal.ansiBrightMagenta": "#9d5cff",
+    "terminal.ansiCyan": "#0e8aa0",
+    "terminal.ansiBrightCyan": "#1aa6bd",
+    "terminal.ansiWhite": "#52525b",
+    "terminal.ansiBrightWhite": "#0c0c0d",
+
+    "scrollbar.shadow": "#00000000",
+    "scrollbarSlider.background": "#00000014",
+    "scrollbarSlider.hoverBackground": "#00000024",
+    "scrollbarSlider.activeBackground": "#00000033",
+    "minimap.background": "#f7f7f5",
+
+    "breadcrumb.foreground": "#8a8a90",
+    "breadcrumb.focusForeground": "#52525b",
+    "breadcrumb.background": "#f7f7f5",
+
+    "gitDecoration.modifiedResourceForeground": "#b07814",
+    "gitDecoration.untrackedResourceForeground": "#1f9d57",
+    "gitDecoration.addedResourceForeground": "#1f9d57",
+    "gitDecoration.deletedResourceForeground": "#c0392b",
+    "gitDecoration.ignoredResourceForeground": "#b8b8b0",
+    "gitDecoration.conflictingResourceForeground": "#d6402c",
+
+    "notifications.background": "#ffffff",
+    "notifications.border": "#e3e3dd",
+    "notificationCenterHeader.background": "#f1f1ee",
+    "notificationsErrorIcon.foreground": "#c0392b",
+    "notificationsWarningIcon.foreground": "#b07814",
+    "notificationsInfoIcon.foreground": "#2563b8",
+
+    "menu.background": "#ffffff",
+    "menu.foreground": "#0c0c0d",
+    "menu.border": "#e3e3dd",
+    "menu.selectionBackground": "#e9e9e4",
+    "menu.selectionForeground": "#0c0c0d",
+    "menubar.selectionBackground": "#e9e9e4",
+
+    "pickerGroup.foreground": "#d6402c",
+    "pickerGroup.border": "#e3e3dd",
+    "quickInput.background": "#ffffff",
+    "quickInputList.focusBackground": "#e9e9e4",
+
+    "textLink.foreground": "#d6402c",
+    "textLink.activeForeground": "#ff5d4d",
+    "textCodeBlock.background": "#eeeeea",
+    "textPreformat.foreground": "#1f9d57"
+  },
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment", "string.comment"],
+      "settings": { "foreground": "#8a8a90", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["string", "string.quoted", "string.template", "punctuation.definition.string"],
+      "settings": { "foreground": "#1f8a4c" }
+    },
+    {
+      "scope": ["constant.numeric", "constant.language", "constant.character", "constant.other"],
+      "settings": { "foreground": "#a06b12" }
+    },
+    {
+      "scope": ["keyword", "keyword.control", "storage", "storage.type", "storage.modifier", "keyword.operator.new"],
+      "settings": { "foreground": "#d6402c" }
+    },
+    {
+      "scope": ["keyword.operator"],
+      "settings": { "foreground": "#44444a" }
+    },
+    {
+      "scope": ["entity.name.function", "support.function", "meta.function-call.generic"],
+      "settings": { "foreground": "#2563b8" }
+    },
+    {
+      "scope": ["entity.name.type", "entity.name.class", "support.type", "support.class", "entity.other.inherited-class"],
+      "settings": { "foreground": "#0e7d92" }
+    },
+    {
+      "scope": ["variable", "variable.other", "meta.definition.variable.name", "support.variable"],
+      "settings": { "foreground": "#1c1c1f" }
+    },
+    {
+      "scope": ["variable.parameter"],
+      "settings": { "foreground": "#6b5a2e" }
+    },
+    {
+      "scope": ["variable.language", "variable.language.this"],
+      "settings": { "foreground": "#c0392b", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["variable.other.property", "support.variable.property", "meta.object-literal.key"],
+      "settings": { "foreground": "#1d5fa8" }
+    },
+    {
+      "scope": ["entity.name.tag", "punctuation.definition.tag"],
+      "settings": { "foreground": "#d6402c" }
+    },
+    {
+      "scope": ["entity.other.attribute-name"],
+      "settings": { "foreground": "#a06b12" }
+    },
+    {
+      "scope": ["support.type.property-name.css", "entity.name.tag.css"],
+      "settings": { "foreground": "#2563b8" }
+    },
+    {
+      "scope": ["markup.heading", "entity.name.section.markdown", "markup.heading.markdown"],
+      "settings": { "foreground": "#d6402c", "fontStyle": "bold" }
+    },
+    {
+      "scope": ["markup.bold"],
+      "settings": { "foreground": "#0c0c0d", "fontStyle": "bold" }
+    },
+    {
+      "scope": ["markup.italic"],
+      "settings": { "fontStyle": "italic" }
+    },
+    {
+      "scope": ["markup.inline.raw", "markup.fenced_code", "markup.raw.markdown"],
+      "settings": { "foreground": "#1f8a4c" }
+    },
+    {
+      "scope": ["markup.underline.link", "string.other.link"],
+      "settings": { "foreground": "#2563b8" }
+    },
+    {
+      "scope": ["entity.name.tag.yaml", "punctuation.support.type.property-name"],
+      "settings": { "foreground": "#1d5fa8" }
+    },
+    {
+      "scope": ["support.type.property-name.json"],
+      "settings": { "foreground": "#1d5fa8" }
+    },
+    {
+      "scope": ["invalid", "invalid.illegal"],
+      "settings": { "foreground": "#c0392b" }
+    },
+    {
+      "scope": ["token.info-token"],
+      "settings": { "foreground": "#2563b8" }
+    },
+    {
+      "scope": ["token.warn-token"],
+      "settings": { "foreground": "#a06b12" }
+    },
+    {
+      "scope": ["token.error-token"],
+      "settings": { "foreground": "#c0392b" }
+    }
+  ]
+}


### PR DESCRIPTION
## What

- **AIOS Dark + AIOS Light workbench themes** bundled (), built from the exact Glass tokens — editor/terminal/activity-bar/tabs match the panels.
- **Theme co-switch (opt-in, never hijacks):** cog *Theme (Glass + IDE)* sets both; the header toggle co-switches when on an AIOS theme, and asks *Glass-only vs Glass + IDE* when off one (no sticky memory). Webview no longer flips optimistically — the extension drives the flip after you choose.
- **Explorer auto-updates in place** via targeted per-folder re-list (no full repaint, no flicker, git-marker path untouched). ⟳ manual refresh as catch-all.
- **Fix:** adding a Workspace folder refreshes immediately (fsList timeout + idempotent resolve + reveal-on-add).

## Verified
Local gate green: compile · 16/16 unit tests · smoke (both panels) · vsix packages (themes included). Headless harness confirmed in-place re-list adds a new row without repaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)